### PR TITLE
Configuration Enhancements and bug fixes

### DIFF
--- a/src/main/java/theflogat/technomancy/common/blocks/base/TMBlocks.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/base/TMBlocks.java
@@ -38,7 +38,6 @@ import theflogat.technomancy.common.tiles.thaumcraft.machine.TileTeslaCoil;
 import theflogat.technomancy.common.tiles.thaumcraft.storage.TileCreativeJar;
 import theflogat.technomancy.common.tiles.thaumcraft.storage.TileEssentiaContainer;
 import theflogat.technomancy.handlers.compat.CoFH;
-import theflogat.technomancy.handlers.compat.ThermalExpansion;
 import theflogat.technomancy.lib.Ids;
 import theflogat.technomancy.lib.Names;
 import net.minecraft.block.Block;
@@ -135,9 +134,9 @@ public class TMBlocks {
 		processorBM = Ids.processorBM ? new BlockProcessor.BlockBMProcessor() : null;
 
 		//Registry
-		GameRegistry.registerBlock(bloodDynamo, Names.bloodDynamo);
-		GameRegistry.registerBlock(bloodFabricator, Names.bloodFabricator);
-		GameRegistry.registerBlock(processorBM, Names.processor + "BM");
+		registerBlock(bloodDynamo, Names.bloodDynamo);
+		registerBlock(bloodFabricator, Names.bloodFabricator);
+		registerBlock(processorBM, Names.processor + "BM");
 
 		//Tiles registry
 		GameRegistry.registerTileEntity(TileBloodDynamo.class, "TileBloodDynamo");
@@ -153,9 +152,9 @@ public class TMBlocks {
 		processorBO = Ids.processorBO ? new BlockProcessor.BlockBOProcessor() : null;
 		
 		//Block Registry
-		GameRegistry.registerBlock(flowerDynamo, Names.flowerDynamo);
-		GameRegistry.registerBlock(manaFabricator, Names.manaFabricator);
-		GameRegistry.registerBlock(processorBO, Names.processor + "BO");
+		registerBlock(flowerDynamo, Names.flowerDynamo);
+		registerBlock(manaFabricator, Names.manaFabricator);
+		registerBlock(processorBO, Names.processor + "BO");
 
 		//Tile Registry
 		GameRegistry.registerTileEntity(TileFlowerDynamo.class, "TileFlowerDynamo");

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileBiomeMorpher.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileBiomeMorpher.java
@@ -12,21 +12,22 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.api.nodes.NodeType;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Thaumcraft;
+import theflogat.technomancy.lib.Costs;
 
 public class TileBiomeMorpher extends TileMachineBase implements INode{	
 	
 	private AspectList aspects = new AspectList();
-	private int amount = 35;
-	public static int cost = 20000;
+	//private int amount = 35;
+	public static int cost = Costs.biomeMorpherCost;
 	
 	public TileBiomeMorpher() {
-		super(800000);
+		super(Costs.biomeMorpherCost * 40);
 	}
 	
 	@Override
 	public void updateEntity() {
 		if(!worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)) {
-			if (getEnergyStored() > cost) {
+			if (getEnergyStored() >= cost) {
 				alterBiome();
 				alterBiome();
 				extractEnergy(cost, false);
@@ -45,7 +46,7 @@ public class TileBiomeMorpher extends TileMachineBase implements INode{
 		BiomeGenBase bg = worldObj.getBiomeGenForCoords(xx, zz);
 		if (bg.biomeID != bm.biomeID) {
 			try {
-				Class Utils = Class.forName("thaumcraft.common.lib.utils.Utils");
+				Class<?> Utils = Class.forName("thaumcraft.common.lib.utils.Utils");
 				for(Method method : Utils.getMethods()){
 					if(method.getName().equalsIgnoreCase("setBiomeAt")){
 						method.invoke(null, worldObj, xx, zz, bm);
@@ -69,7 +70,7 @@ public class TileBiomeMorpher extends TileMachineBase implements INode{
 		BiomeGenBase bg = this.worldObj.getBiomeGenForCoords(xx, zz);
 		if (bg.biomeID != bm.biomeID) {
 			try {
-				Class Utils = Class.forName("thaumcraft.common.lib.utils.Utils");
+				Class<?> Utils = Class.forName("thaumcraft.common.lib.utils.Utils");
 				for(Method method : Utils.getMethods()){
 					if(method.getName().equalsIgnoreCase("setBiomeAt")){
 						method.invoke(null, worldObj, xx, zz, bm);

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileBloodFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileBloodFabricator.java
@@ -3,6 +3,7 @@ package theflogat.technomancy.common.tiles.thaumcraft.machine;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.BloodMagic;
 import theflogat.technomancy.handlers.util.WorldHelper;
+import theflogat.technomancy.lib.Costs;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -11,16 +12,15 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
-import cofh.api.energy.EnergyStorage;
 
 public class TileBloodFabricator extends TileMachineBase implements IFluidHandler {
 	
 	public FluidTank tank = new FluidTank(10000);
-	public static int cost = 1000000;
+	public static int cost = Costs.bloodFabCost;
 	int count = 0;
 	
 	public TileBloodFabricator() {
-		super(50000000);
+		super(Costs.bloodFabCost * 50);
 	}
 	@Override
 	public void updateEntity() {

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileCondenser.java
@@ -1,15 +1,13 @@
 package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectSource;
 import thaumcraft.api.aspects.IEssentiaTransport;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
-import theflogat.technomancy.handlers.compat.Thaumcraft;
-import cofh.api.energy.EnergyStorage;
+import theflogat.technomancy.lib.Costs;
 
 public class TileCondenser extends TileMachineBase implements IEssentiaTransport, IAspectSource {
 
@@ -17,10 +15,10 @@ public class TileCondenser extends TileMachineBase implements IEssentiaTransport
 	
 	public int amount = 0;
 	public int maxAmount = 64;
-	public static int cost = 200000;// 200 000
+	public static int cost = Costs.condenserCost;
 
 	public TileCondenser() {
-		super(1000000);// 1 000 000
+		super(Costs.condenserCost * 5);
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
@@ -16,6 +16,7 @@ import thaumcraft.api.aspects.IEssentiaTransport;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Thaumcraft;
 import theflogat.technomancy.handlers.util.Coords;
+import theflogat.technomancy.lib.Costs;
 
 public class TileEldritchConsumer extends TileMachineBase implements IAspectContainer, IEssentiaTransport{
 	
@@ -73,20 +74,21 @@ public class TileEldritchConsumer extends TileMachineBase implements IAspectCont
 	public int cooldown = 0;
 	public int time = 0;
 	public float panelRotation = 0;
+	public int cost = Costs.consumerCost;
 
 	public TileEldritchConsumer() {
-		super(1000000);
+		super(Costs.consumerCost * 50);
 	}
 
 	@Override
 	public void updateEntity() {
 		if(!worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)) {
 			if(time<=0 && canFillList(list)){
-				if (getEnergyStored() > 20000) {
+				if (getEnergyStored() >= cost) {
 					Coords c = seekForBlock();
 					if(c!=null){
 						processFromCoords(c);
-						extractEnergy(20000, false);
+						extractEnergy(cost, false);
 						worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 						cooldown = 40;
 					}else{

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
@@ -6,8 +6,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import thaumcraft.api.aspects.AspectList;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Thaumcraft;
-import cofh.api.energy.EnergyStorage;
-
+import theflogat.technomancy.lib.Costs;
 
 public class TileElectricBellows extends TileMachineBase {
 
@@ -15,9 +14,10 @@ public class TileElectricBellows extends TileMachineBase {
 	public float inflation = 1.0F;
 	boolean firstrun = false;;
 	boolean direction = false;
+	public int baseCost = Costs.bellowsCost;
 
 	public TileElectricBellows() {
-		super(20000);
+		super(Costs.bellowsCost * 40);
 	}
 	@Override
 	public void writeCustomNBT(NBTTagCompound compound) {
@@ -41,7 +41,7 @@ public class TileElectricBellows extends TileMachineBase {
 			}			
 			if(furnace != null) {
 				if(Thaumcraft.TileAlchemyFurnace.isInstance(furnace)) {
-					if(extractEnergy(3000, true) == 3000) {
+					if(extractEnergy(baseCost * 6, true) == baseCost * 6) {
 						if(((ISidedInventory)furnace).getStackInSlot(0) == null || ((ISidedInventory)furnace).getStackInSlot(1) != null) {
 							return;
 						}
@@ -53,16 +53,16 @@ public class TileElectricBellows extends TileMachineBase {
 						if(((int)Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace)) <= 2 &&
 								((AspectList)Thaumcraft.TileAlchemyFurnace.getField("aspects").get(furnace)).visSize() + al.visSize() < 50) {
 							Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").set(furnace, 80);
-							extractEnergy(3000, false);
+							extractEnergy(baseCost * 6, false);
 						}					
 					}
 				}
 				if(Thaumcraft.TileArcaneFurnace.isInstance(furnace)) {
-					if(extractEnergy(500, true) == 500) {
+					if(extractEnergy(baseCost, true) == baseCost) {
 						if(((int)Thaumcraft.TileArcaneFurnace.getField("furnaceCookTime").getInt(furnace)) > 6) {
 							Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").set(furnace, 
 									((int)Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace))-6);
-							extractEnergy(500, false);
+							extractEnergy(baseCost, false);
 						}
 					}
 				}

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileManaFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileManaFabricator.java
@@ -7,6 +7,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import theflogat.technomancy.common.blocks.base.TMBlocks;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Botania;
+import theflogat.technomancy.lib.Costs;
 import vazkii.botania.api.mana.IManaPool;
 
 public class TileManaFabricator extends TileMachineBase implements IManaPool {
@@ -14,10 +15,10 @@ public class TileManaFabricator extends TileMachineBase implements IManaPool {
 	public int maxMana = 100000;
 	public int mana;
 	public int facing;
-	public static int cost = 20000;
+	public static int cost = Costs.manaFabCost;
 
 	public TileManaFabricator() {
-		super(30000);
+		super(Costs.manaFabCost * 2);
 	}
 	@Override
 	public void updateEntity() {

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileManaFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileManaFabricator.java
@@ -8,7 +8,6 @@ import theflogat.technomancy.common.blocks.base.TMBlocks;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Botania;
 import vazkii.botania.api.mana.IManaPool;
-import cofh.api.energy.EnergyStorage;
 
 public class TileManaFabricator extends TileMachineBase implements IManaPool {
 	
@@ -22,7 +21,7 @@ public class TileManaFabricator extends TileMachineBase implements IManaPool {
 	}
 	@Override
 	public void updateEntity() {
-		if(getEnergyStored()>cost && mana+100<maxMana) {
+		if(getEnergyStored()>=cost && mana+100<=maxMana) {
 			mana += 100;
 			extractEnergy(cost, false);
 			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
@@ -48,7 +47,7 @@ public class TileManaFabricator extends TileMachineBase implements IManaPool {
 
 	@Override
 	public void recieveMana(int mana) {
-		mana += mana;		
+		this.mana += mana;		
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTeslaCoil.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTeslaCoil.java
@@ -19,7 +19,7 @@ import theflogat.technomancy.lib.Conf;
 public class TileTeslaCoil extends TileTechnomancy {
 
 	public Aspect aspectFilter = null;
-	public ArrayList<ChunkCoordinates> sources = new ArrayList();
+	public ArrayList<ChunkCoordinates> sources = new ArrayList<ChunkCoordinates>();
 	public int facing = 0;
 
 
@@ -58,10 +58,10 @@ public class TileTeslaCoil extends TileTechnomancy {
 	public void updateEntity() {
 		TileEntity te = Thaumcraft.getConnectableAsContainer(worldObj, xCoord, yCoord, zCoord, ForgeDirection.getOrientation(facing));
 		if (te != null && !sources.isEmpty()) {
-			ForgeDirection opp = ForgeDirection.VALID_DIRECTIONS[facing].getOpposite();
+			//ForgeDirection opp = ForgeDirection.VALID_DIRECTIONS[facing].getOpposite();
 			IAspectContainer cont;
 			if(te instanceof IAspectContainer){
-				 cont = (IAspectContainer)te;
+				cont = (IAspectContainer)te;
 			}else{
 				cont = new AspectContainerEssentiaTransport((IEssentiaTransport) te);
 			}
@@ -74,15 +74,18 @@ public class TileTeslaCoil extends TileTechnomancy {
 					for(int ii = 0; ii < al.size(); ii++) {
 						Aspect aspect = al.getAspects()[ii];
 						if(aspect != null && (aspectFilter == null || aspect == aspectFilter) && cont.doesContainerAccept(aspect)) {
-							int color = aspect.getColor();					
-							if(source.takeFromContainer(aspect, 1)) {
-								cont.addToContainer(aspect, 1);
-								if(Conf.fancy) {
-									if(this!=null && tile!=null && color>0 && source!=null) {
-										Technomancy.proxy.essentiaTrail(worldObj, (double)xCoord + 0.5D, (double)yCoord + 0.5D,
-												(double)zCoord + 0.5D, (double)(tile.xCoord) + 0.5D, (double)(tile.yCoord) + 0.5D,
-												(double)(tile.zCoord) + 0.5D, color);
+							int color = aspect.getColor();
+							if(cont.addToContainer(aspect, 1) == 0) {
+								if(source.takeFromContainer(aspect, 1)) {
+									if(Conf.fancy) {
+										if(this!=null && tile!=null && color>0 && source!=null) {
+											Technomancy.proxy.essentiaTrail(worldObj, (double)xCoord + 0.5D, (double)yCoord + 0.5D,
+													(double)zCoord + 0.5D, (double)(tile.xCoord) + 0.5D, (double)(tile.yCoord) + 0.5D,
+													(double)(tile.zCoord) + 0.5D, color);
+										}
 									}
+								} else {
+									cont.takeFromContainer(aspect, 1);
 								}
 							}
 						}						

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/util/AspectContainerEssentiaTransport.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/util/AspectContainerEssentiaTransport.java
@@ -16,7 +16,13 @@ public class AspectContainerEssentiaTransport implements IAspectContainer{
 
 	@Override
 	public AspectList getAspects() {
-		return null;
+		AspectList as = new AspectList();
+		for(ForgeDirection dir: ForgeDirection.VALID_DIRECTIONS){
+			if(trans.getEssentiaType(dir)!=null){
+				as.add(trans.getEssentiaType(dir), trans.getEssentiaAmount(dir));
+			}
+		}
+		return as;
 	}
 
 	@Override
@@ -35,42 +41,55 @@ public class AspectContainerEssentiaTransport implements IAspectContainer{
 
 	@Override
 	public int addToContainer(Aspect tag, int amount) {
+		int amountSent = 0;
+		int amountToSend = amount;
 		for(ForgeDirection dir: ForgeDirection.VALID_DIRECTIONS){
-			int i = trans.addEssentia(tag, amount, dir);
-			if(i!=0){
-				return i;
-			}
+			int i = trans.addEssentia(tag, amountToSend, dir);
+			amountToSend -= i;
+			amountSent += i;
+			if (amountToSend <= 0) break;
 		}
-		return 0;
+		return amount - amountSent;
 	}
 
 	@Override
 	public boolean takeFromContainer(Aspect tag, int amount) {
-		// TODO Auto-generated method stub
+		for(ForgeDirection dir: ForgeDirection.VALID_DIRECTIONS){
+			if (trans.getEssentiaType(dir) == tag && trans.getEssentiaAmount(dir) >= amount) {
+				trans.takeEssentia(tag, amount, dir);
+				return true;
+			}
+		}
 		return false;
 	}
 
 	@Override
 	public boolean takeFromContainer(AspectList ot) {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public boolean doesContainerContainAmount(Aspect tag, int amount) {
-		// TODO Auto-generated method stub
+		for(ForgeDirection dir: ForgeDirection.VALID_DIRECTIONS){
+			if (trans.getEssentiaType(dir) == tag && trans.getEssentiaAmount(dir) >= amount) {
+				return true;
+			}
+		}
 		return false;
 	}
 
 	@Override
 	public boolean doesContainerContain(AspectList ot) {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public int containerContains(Aspect tag) {
-		// TODO Auto-generated method stub
+		for(ForgeDirection dir: ForgeDirection.VALID_DIRECTIONS){
+			if (trans.getEssentiaType(dir) == tag) {
+				return trans.getEssentiaAmount(dir);
+			}
+		}
 		return 0;
 	}
 }

--- a/src/main/java/theflogat/technomancy/handlers/handlers/ConfigHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/ConfigHandler.java
@@ -3,6 +3,7 @@ package theflogat.technomancy.handlers.handlers;
 import java.io.File;
 
 import theflogat.technomancy.lib.Conf;
+import theflogat.technomancy.lib.Costs;
 import theflogat.technomancy.lib.Ids;
 import theflogat.technomancy.lib.Names;
 import net.minecraftforge.common.config.Configuration;
@@ -67,6 +68,14 @@ public class ConfigHandler {
         
        	Conf.debug = config.get("Misc", "DebugFunction", Conf.debug).getBoolean(Conf.debug);
 
+       	//RF Costs
+       	Costs.manaFabCost = config.get("Costs", "ManaFabricator", Costs.manaFabCost).getInt(Costs.manaFabCost);
+       	Costs.bloodFabCost = config.get("Costs", "BloodFabricator", Costs.bloodFabCost).getInt(Costs.bloodFabCost);
+       	Costs.condenserCost = config.get("Costs", "Condenser", Costs.condenserCost).getInt(Costs.condenserCost);
+       	Costs.biomeMorpherCost = config.get("Costs", "BiomeMorpher", Costs.biomeMorpherCost).getInt(Costs.biomeMorpherCost);
+       	Costs.consumerCost = config.get("Costs", "EldritchConsumer", Costs.consumerCost).getInt(Costs.consumerCost);
+       	Costs.bellowsCost = config.get("Costs", "ElectricBellows", Costs.bellowsCost).getInt(Costs.bellowsCost);
+       	
         config.save();
 
     }

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -449,7 +449,7 @@ public class CraftingHandler {
 				//Normal Recipes
 				GameRegistry.addShapedRecipe(new ItemStack(TMBlocks.bloodFabricator), 
 						new Object[] {" T ", "IMI", "CAC",
-					'T', new ItemStack(Blocks.glass, 1, 3),
+					'T', new ItemStack(Blocks.glass, 1, 0),
 					'I', new ItemStack(TMItems.itemBM, 1, 0),
 					'M', new ItemStack(Blocks.redstone_block, 1, 0),
 					'C', new ItemStack(TMItems.itemBM, 1, 1),

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -261,7 +261,15 @@ public class CraftingHandler {
 						.add(Aspect.EARTH, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60).add(Aspect.ENTROPY, 60), 
 						new Object[]{"  C", " R ", "C  ", 
 					Character.valueOf('C'), ((WandCap)WandCap.caps.get("thaumium")).getItem(), 
-					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()		});
+					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+				electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("void"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 87).add(Aspect.ORDER, 87)
+						.add(Aspect.EARTH, 87).add(Aspect.FIRE, 87).add(Aspect.WATER, 87).add(Aspect.ENTROPY, 87), 
+						new Object[]{"  C", " R ", "C  ", 
+					Character.valueOf('C'), ((WandCap)WandCap.caps.get("void")).getItem(), 
+					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
 			}else{
 				//Infusion Recipes
 				ResearchHandler.recipes.put("NodeGenerator", ThaumcraftApi.addInfusionCraftingRecipe("NODEGENERATOR",
@@ -393,6 +401,14 @@ public class CraftingHandler {
 						.add(Aspect.EARTH, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60).add(Aspect.ENTROPY, 60), 
 						new Object[]{"  C", " R ", "C  ", 
 					Character.valueOf('C'), ((WandCap)WandCap.caps.get("thaumium")).getItem(), 
+					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+				electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("void"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 87).add(Aspect.ORDER, 87)
+						.add(Aspect.EARTH, 87).add(Aspect.FIRE, 87).add(Aspect.WATER, 87).add(Aspect.ENTROPY, 87), 
+						new Object[]{"  C", " R ", "C  ", 
+					Character.valueOf('C'), ((WandCap)WandCap.caps.get("void")).getItem(), 
 					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
 			}
 		}catch(Exception e){e.printStackTrace();}

--- a/src/main/java/theflogat/technomancy/lib/Costs.java
+++ b/src/main/java/theflogat/technomancy/lib/Costs.java
@@ -1,0 +1,14 @@
+package theflogat.technomancy.lib;
+
+public final class Costs {
+
+	public Costs() {}
+	
+	public static int manaFabCost = 20000;
+	public static int bloodFabCost = 1000000;
+	public static int condenserCost = 1000000;
+	public static int biomeMorpherCost = 20000;
+	public static int consumerCost = 20000;
+	public static int bellowsCost = 500;
+
+}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,16 +1,17 @@
-[
 {
-  "modid": "gearbox",
-  "name": "Gearbox Mod",
-  "description": "A mod adding better RF power generation.",
-  "version": "${version}",
-  "mcversion": "${mcversion}",
-  "url": "",
-  "updateUrl": "",
-  "authors": ["theflogat"],
-  "credits": "The Forge, MCP and FML guys, for making this possible. All modders for being a source of inspiration. All youtubers/streamers for making me wanting to play minecraft",
-  "logoFile": "",
-  "screenshots": [],
-  "dependencies": []
+  "modListVersion": 2,
+  "modList": [{
+    "modid": "technom",
+    "name": "Technomancy",
+    "description": "Science and magic. What could go wrong?",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
+    "url": "",
+    "updateUrl": "",
+    "authorList": ["Democretes", "theflogat"],
+    "credits": "Azanor for Thaumcraft, CoFH for Thermal Expansion, FTB forums for support and ideas.",
+    "logoFile": "",
+    "screenshots": [],
+    "dependencies": []
+  }]
 }
-]


### PR DESCRIPTION
This adds configuration entries for the RF costs of most of the RF consuming machines for people who want cheaper or more expensive machines. The default costs should be the same. It also fixes the Blood Magic and Botainia blocks not obeying the config when disabled and causing an issue because they still attempt to register with a null block.

Updated mcmod.info so that correct info is displayed in the mods list in-game. You will still need to update build.grade with the correct version numbers as the ones there are out of date!

It adds a Voidmetal capped Energized Wand.

In addition it fixes an issue with the Mana Fabricator that caused it to generate infinite mana, and an issue which caused coils to void essentia if the destination is full.

Sorry to include new functionality and bug fixes in the same pull request. Let me know if you need them broken apart and I will resubmit as multiple requests.