### PR TITLE
Warning fixes

### DIFF
--- a/src/main/java/theflogat/technomancy/client/renderers/blocks/BlockCrystalRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/blocks/BlockCrystalRenderer.java
@@ -3,14 +3,12 @@ package theflogat.technomancy.client.renderers.blocks;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import theflogat.technomancy.common.tiles.technom.TileCrystal;
-import theflogat.technomancy.common.tiles.thaumcraft.machine.TileEldritchConsumer;
 import theflogat.technomancy.lib.RenderIds;
 
 public class BlockCrystalRenderer implements ISimpleBlockRenderingHandler{

--- a/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBMProcessor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBMProcessor.java
@@ -39,7 +39,7 @@ public class ContainerBMProcessor extends Container {
 	public void addCraftingToCrafters(ICrafting craft) {
 		super.addCraftingToCrafters(craft);
 		craft.sendProgressBarUpdate(this, 0, this.processor.progress);
-		craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);		
+		craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);		
 	}
 	
 	@Override
@@ -50,12 +50,12 @@ public class ContainerBMProcessor extends Container {
 			if(this.lastTime != this.processor.progress) {
 				craft.sendProgressBarUpdate(this, 0, this.processor.progress);
 		    }
-			if(this.lastMax != this.processor.maxTime) {
-				craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);
+			if(this.lastMax != TileProcessorBase.maxTime) {
+				craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);
 			}
 		}
 		this.lastTime = this.processor.progress;
-		this.lastMax = this.processor.maxTime;
+		this.lastMax = TileProcessorBase.maxTime;
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBMProcessor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBMProcessor.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.gui.container;
 
 import theflogat.technomancy.common.tiles.base.TileProcessorBase;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileBMProcessor;
-import theflogat.technomancy.common.tiles.thaumcraft.machine.TileTCProcessor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;

--- a/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBOProcessor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerBOProcessor.java
@@ -1,5 +1,6 @@
 package theflogat.technomancy.client.renderers.gui.container;
 
+import theflogat.technomancy.common.tiles.base.TileProcessorBase;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileBOProcessor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -37,7 +38,7 @@ public class ContainerBOProcessor extends Container {
 	public void addCraftingToCrafters(ICrafting craft) {
 		super.addCraftingToCrafters(craft);
 		craft.sendProgressBarUpdate(this, 0, this.processor.progress);
-		craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);		
+		craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);		
 	}
 	
 	@Override
@@ -48,12 +49,12 @@ public class ContainerBOProcessor extends Container {
 			if(this.lastTime != this.processor.progress) {
 				craft.sendProgressBarUpdate(this, 0, this.processor.progress);
 		    }
-			if(this.lastMax != this.processor.maxTime) {
-				craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);
+			if(this.lastMax != TileProcessorBase.maxTime) {
+				craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);
 			}
 		}
 		this.lastTime = this.processor.progress;
-		this.lastMax = this.processor.maxTime;
+		this.lastMax = TileProcessorBase.maxTime;
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerTCProcessor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerTCProcessor.java
@@ -39,7 +39,7 @@ public class ContainerTCProcessor extends Container {
 	public void addCraftingToCrafters(ICrafting craft) {
 		super.addCraftingToCrafters(craft);
 		craft.sendProgressBarUpdate(this, 0, this.processor.progress);
-		craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);		
+		craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);		
 	}
 	
 	@Override
@@ -50,12 +50,12 @@ public class ContainerTCProcessor extends Container {
 			if(this.lastTime != this.processor.progress) {
 				craft.sendProgressBarUpdate(this, 0, this.processor.progress);
 		    }
-			if(this.lastMax != this.processor.maxTime) {
-				craft.sendProgressBarUpdate(this, 1, this.processor.maxTime);
+			if(this.lastMax != TileProcessorBase.maxTime) {
+				craft.sendProgressBarUpdate(this, 1, TileProcessorBase.maxTime);
 			}
 		}
 		this.lastTime = this.processor.progress;
-		this.lastMax = this.processor.maxTime;
+		this.lastMax = TileProcessorBase.maxTime;
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerTCProcessor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/gui/container/ContainerTCProcessor.java
@@ -1,7 +1,6 @@
 package theflogat.technomancy.client.renderers.gui.container;
 
 import theflogat.technomancy.common.tiles.base.TileProcessorBase;
-import theflogat.technomancy.common.tiles.thaumcraft.machine.TileBMProcessor;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileTCProcessor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelBiomeMorpher.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelBiomeMorpher.java
@@ -201,7 +201,8 @@ public class ModelBiomeMorpher extends ModelBase
     model.rotateAngleZ = z;
   }
   
-  public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)  {
+  @Override
+public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)  {
     super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
   }
 

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelBloodDynamo.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 
 public class ModelBloodDynamo extends ModelBase {

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelBloodFabricator.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelBloodFabricator.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 
 public class ModelBloodFabricator extends ModelBase {

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelCrystal.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelCrystal.java
@@ -4,7 +4,6 @@ import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import theflogat.technomancy.common.tiles.technom.TileCrystal;
 
 public class ModelCrystal extends ModelBase{
 	

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelEssentiaContainer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelEssentiaContainer.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 public class ModelEssentiaContainer extends ModelBase{
     ModelRenderer Core;

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelEssentiaDynamo.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelEssentiaDynamo.java
@@ -13,7 +13,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 public class ModelEssentiaDynamo extends ModelBase
 {

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelFlowerDynamo.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelFlowerDynamo.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 public class ModelFlowerDynamo extends ModelBase {
     ModelRenderer Shape1;

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelFluxLamp.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 public class ModelFluxLamp extends ModelBase
 {

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelManaFabricator.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelManaFabricator.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 
 public class ModelManaFabricator extends ModelBase {

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelNodeDynamo.java
@@ -202,7 +202,8 @@ public class ModelNodeDynamo extends ModelBase
     model.rotateAngleZ = z;
   }
   
-  public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)
+  @Override
+public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)
   {
     super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
   }

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelNodeGenerator.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelNodeGenerator.java
@@ -103,7 +103,8 @@ public class ModelNodeGenerator extends ModelBase
     model.rotateAngleZ = z;
   }
   
-  public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)  {
+  @Override
+public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity)  {
     super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
   }
 

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelReconstructor.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelReconstructor.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 
 

--- a/src/main/java/theflogat/technomancy/client/renderers/models/ModelTeslaCoil.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/models/ModelTeslaCoil.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.client.renderers.models;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.entity.Entity;
 
 public class ModelTeslaCoil extends ModelBase
 {

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBiomeMorpherRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBiomeMorpherRenderer.java
@@ -17,6 +17,7 @@ public class TileBiomeMorpherRenderer extends TileEntitySpecialRenderer{
 	
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_BIOME_MODIFIER_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float f) {
 		
 		GL11.glPushMatrix();

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBiomeMorpherRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBiomeMorpherRenderer.java
@@ -7,8 +7,6 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
 import theflogat.technomancy.client.renderers.models.ModelBiomeMorpher;
-import theflogat.technomancy.common.tiles.thaumcraft.machine.TileBiomeMorpher;
-import theflogat.technomancy.handlers.compat.Thaumcraft;
 import theflogat.technomancy.lib.Ref;
 
 public class TileBiomeMorpherRenderer extends TileEntitySpecialRenderer{

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBloodDynamoRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileBloodDynamoRenderer.java
@@ -9,7 +9,6 @@ import org.lwjgl.opengl.GL11;
 import theflogat.technomancy.client.renderers.models.ModelBloodDynamo;
 import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.common.tiles.dynamos.TileBloodDynamo;
-import theflogat.technomancy.handlers.util.Java;
 import theflogat.technomancy.lib.Ref;
 
 public class TileBloodDynamoRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileCreativeJarRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileCreativeJarRenderer.java
@@ -24,6 +24,7 @@ public class TileCreativeJarRenderer extends TileEntitySpecialRenderer {
 
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_ESSENTIA_CONTAINER_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float t) {
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float)x, (float)y, (float)z);

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileCrystalRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileCrystalRenderer.java
@@ -6,10 +6,8 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
-import theflogat.technomancy.client.renderers.models.ModelBloodFabricator;
 import theflogat.technomancy.client.renderers.models.ModelCrystal;
 import theflogat.technomancy.common.tiles.technom.TileCrystal;
-import theflogat.technomancy.common.tiles.thaumcraft.machine.TileBloodFabricator;
 import theflogat.technomancy.lib.Ref;
 
 public class TileCrystalRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileElectricBellowsRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileElectricBellowsRenderer.java
@@ -44,8 +44,6 @@ public class TileElectricBellowsRenderer extends TileEntitySpecialRenderer{
 		}
 		float tscale = 0.125F + scale * 0.875F;
 
-		Minecraft mc = FMLClientHandler.instance().getClient();
-
 		bindTexture(modelTexture);
 		GL11.glPushMatrix();
 		GL11.glEnable(2977);

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileElectricBellowsRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileElectricBellowsRenderer.java
@@ -12,7 +12,6 @@ import org.lwjgl.opengl.GL11;
 import theflogat.technomancy.client.renderers.models.ModelElectricBellows;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileElectricBellows;
 import theflogat.technomancy.lib.Ref;
-import cpw.mods.fml.client.FMLClientHandler;
 
 public class TileElectricBellowsRenderer extends TileEntitySpecialRenderer{
 	

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
@@ -49,9 +49,9 @@ public class TileEssentiaContainerRenderer extends TileEntitySpecialRenderer{
 		        GL11.glPushMatrix();
 		        GL11.glTranslated(0, 1.5, 0);
 		        switch (((TileEssentiaContainer)tile).facing) {
-		        case 3:  GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F); break;
-		        case 5:  GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F); break;
-		        case 4:  GL11.glRotatef(270.0F, 0.0F, 1.0F, 0.0F);
+		        case 2:  GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F); break;
+		        case 4:  GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F); break;
+		        case 5:  GL11.glRotatef(270.0F, 0.0F, 1.0F, 0.0F);
 		        }
 		        
 		        float rot = (((TileEssentiaContainer)tile).aspectFilter.getTag().hashCode() + ((TileEssentiaContainer)tile).xCoord + ((TileEssentiaContainer)tile).facing) % 4 - 2;

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
@@ -61,7 +61,7 @@ public class TileEssentiaContainerRenderer extends TileEntitySpecialRenderer{
 		        if (Thaumcraft.crooked) GL11.glRotatef(rot, 0.0F, 0.0F, 1.0F);
 		        GL11.glRotatef(180F, 0F, 1F, 0F);
 		        GL11.glDisable(GL11.GL_LIGHTING);
-		        Thaumcraft.renderQuadCenteredFromTexture.invoke(null, "textures/models/label.png", 0.5F, 1.0F, 1.0F, 1.0F, (int)-99, (int)771, 1.0F);
+		        Thaumcraft.renderQuadCenteredFromTexture.invoke(null, "textures/models/label.png", 0.5F, 1.0F, 1.0F, 1.0F, -99, 771, 1.0F);
 		        GL11.glEnable(GL11.GL_LIGHTING);
 		        GL11.glRotatef(180F, 0F, 1F, 0F);
 		        GL11.glPopMatrix();

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
@@ -24,6 +24,7 @@ public class TileEssentiaContainerRenderer extends TileEntitySpecialRenderer{
 
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_ESSENTIA_CONTAINER_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float t) {
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float)x, (float)y, (float)z);

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFlowerDynamoRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFlowerDynamoRenderer.java
@@ -7,7 +7,6 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
 import theflogat.technomancy.client.renderers.models.ModelFlowerDynamo;
-import theflogat.technomancy.client.renderers.models.ModelManaFabricator;
 import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.lib.Ref;
 

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFlowerDynamoRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFlowerDynamoRenderer.java
@@ -17,6 +17,7 @@ public class TileFlowerDynamoRenderer extends TileEntitySpecialRenderer{
 	
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_FLOWER_DYANMO_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float f) {
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float)x, (float)y, (float)z);

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFluxLampRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileFluxLampRenderer.java
@@ -37,7 +37,7 @@ public class TileFluxLampRenderer extends TileEntitySpecialRenderer {
 			
 		GL11.glPushMatrix();		
 		if(((TileFluxLamp)entity).tank.getFluidAmount() > 0) {
-			GL11.glColor3f((float)((TileFluxLamp)entity).tank.getFluidAmount(), 0.0F, (float)((TileFluxLamp)entity).tank.getFluidAmount());
+			GL11.glColor3f(((TileFluxLamp)entity).tank.getFluidAmount(), 0.0F, ((TileFluxLamp)entity).tank.getFluidAmount());
 		}
 		model.renderCore();	
 		GL11.glPopMatrix();

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileManaFabricatorRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileManaFabricatorRenderer.java
@@ -16,6 +16,7 @@ public class TileManaFabricatorRenderer extends TileEntitySpecialRenderer{
 	
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_MANA_FABRICATOR_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float f) {
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float)x, (float)y, (float)z);

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileNodeDynamoRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileNodeDynamoRenderer.java
@@ -1,8 +1,6 @@
 package theflogat.technomancy.client.renderers.tiles;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-
 import theflogat.technomancy.client.renderers.models.ModelNodeDynamo;
 import theflogat.technomancy.lib.Ref;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileReconstructorRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileReconstructorRenderer.java
@@ -3,8 +3,6 @@ package theflogat.technomancy.client.renderers.tiles;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.entity.item.EntityItem;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileReconstructorRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileReconstructorRenderer.java
@@ -32,6 +32,7 @@ public class TileReconstructorRenderer extends TileEntitySpecialRenderer{
 
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_RECONSTRUCTOR_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float f) {
 
 		GL11.glPushMatrix();

--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileTeslaCoilRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileTeslaCoilRenderer.java
@@ -18,6 +18,7 @@ public class TileTeslaCoilRenderer extends TileEntitySpecialRenderer {
 	
 	private static final ResourceLocation modelTexture = new ResourceLocation(Ref.MODEL_TESLA_COIL_TEXTURE);
 
+	@Override
 	public void renderTileEntityAt(TileEntity entity, double x, double y, double z, float f) {
 		
 		GL11.glPushMatrix();

--- a/src/main/java/theflogat/technomancy/common/blocks/base/BlockCosmeticOpaque.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/base/BlockCosmeticOpaque.java
@@ -38,17 +38,21 @@ public class BlockCosmeticOpaque extends Block {
 		
 	}
 	
+	@Override
 	public int quantityDropped(Random par1Random) {
 	       return 1;
 	   }
+	@Override
 	@SideOnly(Side.CLIENT)
     public int getRenderBlockPass() {
 		return 1;
 	}
 	
+	@Override
 	public boolean isOpaqueCube() {
 		return false;
 	}
+	@Override
 	public boolean renderAsNormalBlock() {
 		return false;
 	}

--- a/src/main/java/theflogat/technomancy/common/blocks/base/BlockCosmeticPane.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/base/BlockCosmeticPane.java
@@ -31,14 +31,17 @@ public class BlockCosmeticPane extends BlockBase {
 	public void registerBlockIcons(IIconRegister icon) {
 		glassIcon = icon.registerIcon(Ref.TEXTURE_PREFIX + Names.cosmeticOpaque);
 	}
+	@Override
 	public IIcon getIcon(int side, int meta) {
 		return glassIcon;
 	}
 
+	@Override
 	public boolean isOpaqueCube() {
 		return false;
 	}
 	
+	@Override
 	public boolean renderAsNormalBlock() {
 		return false;
 	}
@@ -48,15 +51,18 @@ public class BlockCosmeticPane extends BlockBase {
 		return 1;
 	}
 	
+	@Override
 	public int getRenderType() {
 		return 1;
 	}
     
-    public boolean shouldSideBeRendered(IBlockAccess w, int x, int y, int z, int meta)    {
+    @Override
+	public boolean shouldSideBeRendered(IBlockAccess w, int x, int y, int z, int meta)    {
         return w.getBlock(x, y, z)==this ? false : super.shouldSideBeRendered(w, x, y, z, meta);
     }
     
-    public void addCollisionBoxesToList(World par1World, int par2, int par3, int par4, AxisAlignedBB par5AxisAlignedBB, List par6List, Entity par7Entity)    {
+    @Override
+	public void addCollisionBoxesToList(World par1World, int par2, int par3, int par4, AxisAlignedBB par5AxisAlignedBB, List par6List, Entity par7Entity)    {
         boolean flag = this.canPaneConnectTo(par1World,par2, par3, par4,ForgeDirection.NORTH);
         boolean flag1 = this.canPaneConnectTo(par1World,par2, par3, par4,ForgeDirection.SOUTH);
         boolean flag2 = this.canPaneConnectTo(par1World,par2, par3, par4,ForgeDirection.WEST);
@@ -87,7 +93,8 @@ public class BlockCosmeticPane extends BlockBase {
         }
     }
     
-    public void setBlockBoundsBasedOnState(IBlockAccess par1IBlockAccess, int par2, int par3, int par4)    {
+    @Override
+	public void setBlockBoundsBasedOnState(IBlockAccess par1IBlockAccess, int par2, int par3, int par4)    {
         float f = 0.4375F;
         float f1 = 0.5625F;
         float f2 = 0.4375F;

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
@@ -62,7 +62,6 @@ public class BlockBloodDynamo extends BlockBase {
 
 	@Override   
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-		TileDynamoBase tile = (TileDynamoBase)world.getTileEntity(x, y, z);
 		super.onBlockPlacedBy(world, x, y, z, entity, stack);
 	}  
 

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
@@ -47,7 +47,7 @@ public class BlockBloodDynamo extends BlockBase {
 					}else if(player.getHeldItem().getItem()==BloodMagic.divinationSigil){
 						player.addChatComponentMessage(new ChatComponentText("Energy: " + ((TileBloodDynamo)entity).getEnergyStored(null) + "/" +
 								((TileBloodDynamo)entity).getMaxEnergyStored(null)));
-						player.addChatComponentMessage(new ChatComponentText("Blood: " + ((TileBloodDynamo)entity).liquid + "/" + ((TileBloodDynamo)entity).capacity));
+						player.addChatComponentMessage(new ChatComponentText("Blood: " + ((TileBloodDynamo)entity).liquid + "/" + TileBloodDynamo.capacity));
 					}else if(player.getHeldItem().getItem()==BloodMagic.bucketLife){
 						if(((TileBloodDynamo)entity).emptyBucket())
 							player.inventory.mainInventory[player.inventory.currentItem] = new ItemStack(Items.bucket);

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockBloodDynamo.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.common.blocks.dynamos;
 
 import theflogat.technomancy.common.blocks.base.BlockBase;
 import theflogat.technomancy.common.items.api.ToolWrench;
-import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.common.tiles.dynamos.TileBloodDynamo;
 import theflogat.technomancy.handlers.compat.BloodMagic;
 import theflogat.technomancy.lib.Names;

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockEssentiaDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockEssentiaDynamo.java
@@ -2,7 +2,6 @@ package theflogat.technomancy.common.blocks.dynamos;
 
 import theflogat.technomancy.common.blocks.base.BlockBase;
 import theflogat.technomancy.common.items.api.ToolWrench;
-import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.common.tiles.dynamos.TileEssentiaDynamo;
 import theflogat.technomancy.lib.Names;
 import theflogat.technomancy.lib.Ref;

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockEssentiaDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockEssentiaDynamo.java
@@ -63,7 +63,6 @@ public class BlockEssentiaDynamo extends BlockBase {
 
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-		TileDynamoBase tile = (TileDynamoBase)world.getTileEntity(x, y, z);
 		super.onBlockPlacedBy(world, x, y, z, entity, stack);
 	}   
 

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockFlowerDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockFlowerDynamo.java
@@ -50,7 +50,6 @@ public class BlockFlowerDynamo extends BlockBase implements IWandHUD {
 
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-		TileDynamoBase tile = (TileDynamoBase)world.getTileEntity(x, y, z);
 		super.onBlockPlacedBy(world, x, y, z, entity, stack);
 	}   
 

--- a/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockFlowerDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/dynamos/BlockFlowerDynamo.java
@@ -12,7 +12,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import theflogat.technomancy.common.blocks.base.BlockBase;
 import theflogat.technomancy.common.items.api.ToolWrench;
-import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.common.tiles.dynamos.TileFlowerDynamo;
 import theflogat.technomancy.lib.Names;
 import theflogat.technomancy.lib.Ref;

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockBloodFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockBloodFabricator.java
@@ -49,6 +49,7 @@ public class BlockBloodFabricator extends BlockBase {
 		return false;
 	}
 	
+	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack)    {
         int rotation = MathHelper.floor_double((double)(entity.rotationYaw * 4.0F / 360.0F) + 2.5D) & 3;
         world.setBlockMetadataWithNotify(x, y, z, rotation, 2);

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockBloodFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockBloodFabricator.java
@@ -51,7 +51,7 @@ public class BlockBloodFabricator extends BlockBase {
 	
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack)    {
-        int rotation = MathHelper.floor_double((double)(entity.rotationYaw * 4.0F / 360.0F) + 2.5D) & 3;
+        int rotation = MathHelper.floor_double(entity.rotationYaw * 4.0F / 360.0F + 2.5D) & 3;
         world.setBlockMetadataWithNotify(x, y, z, rotation, 2);
     }
 	

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
@@ -33,6 +33,7 @@ public class BlockCondenser extends BlockBase {
 		return true;
 	}
 
+	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack)    {
 		int rotation = MathHelper.floor_double((double)(entity.rotationYaw * 4.0F / 360.0F) + 2.5D) & 3;
 		world.setBlockMetadataWithNotify(x, y, z, rotation, 2);

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
@@ -35,7 +35,7 @@ public class BlockCondenser extends BlockBase {
 
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack)    {
-		int rotation = MathHelper.floor_double((double)(entity.rotationYaw * 4.0F / 360.0F) + 2.5D) & 3;
+		int rotation = MathHelper.floor_double(entity.rotationYaw * 4.0F / 360.0F + 2.5D) & 3;
 		world.setBlockMetadataWithNotify(x, y, z, rotation, 2);
 	}
 

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
@@ -24,11 +24,6 @@ public class BlockCondenser extends BlockBase {
 	
 	@Override
 	public boolean onBlockActivated(World w, int x,	int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-		TileEntity te = w.getTileEntity(x, y, z);
-//		if(!w.isRemote && te!=null && te instanceof TileCondenser){
-//			player.addChatComponentMessage(new ChatComponentText(((TileCondenser)te).getEnergyStored() + "/" + ((TileCondenser)te).getMaxEnergyStored()));
-//			player.addChatComponentMessage(new ChatComponentText(((TileCondenser)te).amount + "/" + ((TileCondenser)te).maxAmount));
-//		}
 		return true;
 	}
 

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockCondenser.java
@@ -10,7 +10,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockFluxLamp.java
@@ -47,8 +47,6 @@ public class BlockFluxLamp extends BlockBase {
 	
 	@Override
 	public int onBlockPlaced(World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int meta){
-		TileEntity tile = world.getTileEntity(x, y, z);
-		
 		return side + meta;
 	}
 	

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockProcessor.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockProcessor.java
@@ -88,7 +88,6 @@ public class BlockProcessor extends BlockBase {
 	
 	@Override
 	public IIcon getIcon(IBlockAccess access, int x, int y, int z, int side) {
-		int meta = access.getBlockMetadata(x, y, z);
 		TileEntity tile = access.getTileEntity(x, y, z);
 		if(side == 1) {
 			return icons[3];

--- a/src/main/java/theflogat/technomancy/common/blocks/machines/BlockProcessor.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/machines/BlockProcessor.java
@@ -129,10 +129,10 @@ public class BlockProcessor extends BlockBase {
 	    		f += 0.1F;
 	    		f1 += 0.1F;
 	    		f2 += 0.1F;
-		    	Botania.sparkle(world, (double)f - f3, (double)f1, f2 + f4, r);
-		    	Botania.sparkle(world, (double)f + f3, (double)f1, f2 + f4, r);
-		    	Botania.sparkle(world, (double)f + f4, (double)f1, f2 - f3, r);
-		    	Botania.sparkle(world, (double)f + f4, (double)f1, f2 + f3, r);
+		    	Botania.sparkle(world, (double)f - f3, f1, f2 + f4, r);
+		    	Botania.sparkle(world, (double)f + f3, f1, f2 + f4, r);
+		    	Botania.sparkle(world, (double)f + f4, f1, f2 - f3, r);
+		    	Botania.sparkle(world, (double)f + f4, f1, f2 + f3, r);
 		    }
 	    }
 	    

--- a/src/main/java/theflogat/technomancy/common/blocks/storage/BlockCreativeJar.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/storage/BlockCreativeJar.java
@@ -52,6 +52,7 @@ public class BlockCreativeJar extends BlockBase {
 		}
 	}
 	
+	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float vecX, float vecY, float vecZ)  {
 		if (world.getTileEntity(x, y, z) instanceof TileCreativeJar ) {
 			TileCreativeJar container = (TileCreativeJar)world.getTileEntity(x, y, z);	  
@@ -131,6 +132,7 @@ public class BlockCreativeJar extends BlockBase {
 		return true;
 	}	
 
+	@Override
 	public TileEntity createNewTileEntity(World w, int meta) {
 		return new TileCreativeJar();
 	}

--- a/src/main/java/theflogat/technomancy/common/blocks/storage/BlockCreativeJar.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/storage/BlockCreativeJar.java
@@ -100,7 +100,7 @@ public class BlockCreativeJar extends BlockBase {
 //				}
 				//Adds Essentia from Phials
 				if (item.getItem() == Thaumcraft.itemEssence && item.getItemDamage() == 1 && container.amount <= (container.maxAmount - 8)) {
-						if(container.addToContainer(((IEssentiaContainerItem)(IEssentiaContainerItem)player.getHeldItem().getItem())
+						if(container.addToContainer(((IEssentiaContainerItem)player.getHeldItem().getItem())
 								.getAspects(player.getHeldItem()).getAspects()[0], 8) == 0) {
 							item.stackSize -= 1;
 							ItemStack phial = new ItemStack(Thaumcraft.itemEssence, 1, 0);

--- a/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
@@ -103,7 +103,7 @@ public class BlockEssentiaContainer extends BlockBase {
 				}				
 				//Adds Essentia from Phials
 				if (item.getItem() == Thaumcraft.itemEssence && item.getItemDamage() == 1 && container.amount <= (container.maxAmount - 8)) {
-						if(container.addToContainer(((IEssentiaContainerItem)(IEssentiaContainerItem)player.getHeldItem().getItem())
+						if(container.addToContainer(((IEssentiaContainerItem)player.getHeldItem().getItem())
 								.getAspects(player.getHeldItem()).getAspects()[0], 8) == 0) {
 							item.stackSize -= 1;
 							ItemStack phial = new ItemStack(Thaumcraft.itemEssence, 1, 0);

--- a/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
@@ -54,6 +54,7 @@ public class BlockEssentiaContainer extends BlockBase {
 		}
 	}
 	
+	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float vecX, float vecY, float vecZ)  {
 		if (world.getTileEntity(x, y, z) instanceof TileEssentiaContainer ) {
 			TileEssentiaContainer container = (TileEssentiaContainer)world.getTileEntity(x, y, z);	  
@@ -134,6 +135,7 @@ public class BlockEssentiaContainer extends BlockBase {
 		return true;
 	}	
 
+	@Override
 	public TileEntity createNewTileEntity(World w, int meta) {
 		return new TileEssentiaContainer();
 	}

--- a/src/main/java/theflogat/technomancy/common/items/ElectricWandUpdate.java
+++ b/src/main/java/theflogat/technomancy/common/items/ElectricWandUpdate.java
@@ -1,14 +1,9 @@
 package theflogat.technomancy.common.items;
 
-import java.lang.reflect.InvocationTargetException;
-
 import cofh.api.energy.IEnergyContainerItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.api.wands.IWandRodOnUpdate;
 import theflogat.technomancy.handlers.compat.Thaumcraft;
 

--- a/src/main/java/theflogat/technomancy/common/items/ItemBMMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemBMMaterial.java
@@ -22,21 +22,25 @@ public class ItemBMMaterial extends ItemBase {
 	
 	public IIcon[] itemIcon = new IIcon[2];
 	
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		itemIcon[0] = icon.registerIcon(Ref.TEXTURE_PREFIX + "sacrificialIngot");
 		itemIcon[1] = icon.registerIcon(Ref.TEXTURE_PREFIX + "bloodCoil");
 	}
 	
+	@Override
 	@SideOnly(Side.CLIENT)
 	public IIcon getIconFromDamage(int par) {
 		return this.itemIcon[par];
 	}
 	
+	@Override
 	public String getUnlocalizedName(ItemStack stack) {
 		return Ref.MOD_PREFIX + Names.itemBM + "." + stack.getItemDamage();
 	}
 	
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {

--- a/src/main/java/theflogat/technomancy/common/items/ItemBMMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemBMMaterial.java
@@ -40,6 +40,7 @@ public class ItemBMMaterial extends ItemBase {
 		return Ref.MOD_PREFIX + Names.itemBM + "." + stack.getItemDamage();
 	}
 	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	@SideOnly(Side.CLIENT)
 	public void getSubItems(Item id, CreativeTabs tab, List list) {

--- a/src/main/java/theflogat/technomancy/common/items/ItemBOMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemBOMaterial.java
@@ -22,21 +22,25 @@ public class ItemBOMaterial extends ItemBase {
 	
 	public IIcon[] itemIcon = new IIcon[2];
 	
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		itemIcon[0] = icon.registerIcon(Ref.TEXTURE_PREFIX + "manaCoil");
 		itemIcon[1] = icon.registerIcon(Ref.TEXTURE_PREFIX + "manaGear");
 	}
 	
+	@Override
 	@SideOnly(Side.CLIENT)
 	public IIcon getIconFromDamage(int meta) {
 		return itemIcon[meta];
 	}
 	
+	@Override
 	public String getUnlocalizedName(ItemStack stack) {
 		return Ref.MOD_PREFIX + Names.itemBO + "." + stack.getItemDamage();
 	}
 	
+	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {
 			ItemStack stack  = new ItemStack(id, 1, i);

--- a/src/main/java/theflogat/technomancy/common/items/ItemBOMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemBOMaterial.java
@@ -40,6 +40,7 @@ public class ItemBOMaterial extends ItemBase {
 		return Ref.MOD_PREFIX + Names.itemBO + "." + stack.getItemDamage();
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {

--- a/src/main/java/theflogat/technomancy/common/items/ItemEssentiaCannon.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemEssentiaCannon.java
@@ -19,6 +19,7 @@ public class ItemEssentiaCannon extends ItemBase {
 		setUnlocalizedName(Ref.MOD_PREFIX + Names.essentiaCannon);
 	}	
 	
+	@Override
 	public ItemStack onItemRightClick(ItemStack itemstack, World world, EntityPlayer player){
 	  	if (!world.isRemote) {
 	  	    if(!player.isSneaking()) {
@@ -36,10 +37,12 @@ public class ItemEssentiaCannon extends ItemBase {
 		return damage >= 2;
 	}
 	
+	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List info, boolean useExtraInformation) {
 		info.add("Charge: " + (itemstack.getItemDamage() + 1));
 	}
 	
+	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int sideHit, float hitVecX, float hitVecY, float hitVecZ) {
 	    if (world.isRemote) {
 	            if(player.isSneaking()){

--- a/src/main/java/theflogat/technomancy/common/items/ItemPen.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemPen.java
@@ -67,15 +67,18 @@ public class ItemPen extends ItemBase implements IScribeTools {
 		return false;
 	}
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		itemIcon = icon.registerIcon(Ref.TEXTURE_PREFIX + "penItem");
 	}
 
+	@Override
 	public String getUnlocalizedName(ItemStack stack) {
 		return Ref.MOD_PREFIX + Names.pen;
 	}
 
+	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List info, boolean useExtraInformation) {
 		info.add("It's the 21st century,");
 		info.add("why are we using quills and ink?");

--- a/src/main/java/theflogat/technomancy/common/items/ItemPen.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemPen.java
@@ -78,6 +78,7 @@ public class ItemPen extends ItemBase implements IScribeTools {
 		return Ref.MOD_PREFIX + Names.pen;
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List info, boolean useExtraInformation) {
 		info.add("It's the 21st century,");

--- a/src/main/java/theflogat/technomancy/common/items/ItemProcessedOre.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemProcessedOre.java
@@ -34,6 +34,7 @@ public class ItemProcessedOre extends ItemBase {
 
 	public IIcon[] itemIcon = new IIcon[6];
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		for(int i = 0; i<itemIcon.length; i++){
@@ -41,6 +42,7 @@ public class ItemProcessedOre extends ItemBase {
 		}
 	}
 	
+	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {
 			ItemStack stack  = new ItemStack(id, 1, i);

--- a/src/main/java/theflogat/technomancy/common/items/ItemProcessedOre.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemProcessedOre.java
@@ -42,6 +42,7 @@ public class ItemProcessedOre extends ItemBase {
 		}
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {
@@ -73,6 +74,7 @@ public class ItemProcessedOre extends ItemBase {
 		return items;
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
 		if(!(Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))) {

--- a/src/main/java/theflogat/technomancy/common/items/ItemTHMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemTHMaterial.java
@@ -40,6 +40,7 @@ public class ItemTHMaterial extends ItemBase {
 		itemIcon[4] = icon.registerIcon(Ref.TEXTURE_PREFIX + "coilCoupler");
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void addInformation(ItemStack items, EntityPlayer player, List list, boolean moreInfo) {
 		if(items.getItemDamage()==4){
@@ -79,6 +80,7 @@ public class ItemTHMaterial extends ItemBase {
 		return Ref.MOD_PREFIX + Names.itemMaterial + "." + stack.getItemDamage();
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {

--- a/src/main/java/theflogat/technomancy/common/items/ItemTHMaterial.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemTHMaterial.java
@@ -30,6 +30,7 @@ public class ItemTHMaterial extends ItemBase {
 
 	public IIcon[] itemIcon = new IIcon[5];
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		itemIcon[0] = icon.registerIcon(Ref.TEXTURE_PREFIX + "neutronizedMetal");
@@ -67,6 +68,7 @@ public class ItemTHMaterial extends ItemBase {
 		}
 	}
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public IIcon getIconFromDamage(int dmg) {
 		return this.itemIcon[dmg];
@@ -77,6 +79,7 @@ public class ItemTHMaterial extends ItemBase {
 		return Ref.MOD_PREFIX + Names.itemMaterial + "." + stack.getItemDamage();
 	}
 	
+	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		for (int i = 0; i < itemIcon.length; i++) {
 			ItemStack stack  = new ItemStack(id, 1, i);

--- a/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
@@ -48,8 +48,8 @@ public class ItemWandCores extends ItemBase{
 				list.add(stack);
 			}
 			ItemStack electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
-			Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("thaumium"));
-			Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+			Thaumcraft.setCap.invoke(electric.getItem(), electric, WandCap.caps.get("thaumium"));
+			Thaumcraft.setRod.invoke(electric.getItem(), electric, WandRod.rods.get("electric"));
 			list.add(electric);
 		}catch(Exception e){}
 	}

--- a/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
@@ -40,6 +40,7 @@ public class ItemWandCores extends ItemBase{
 		return Ref.MOD_PREFIX + Names.wandCores + "." + stack.getItemDamage();
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		try{

--- a/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
+++ b/src/main/java/theflogat/technomancy/common/items/ItemWandCores.java
@@ -23,20 +23,24 @@ public class ItemWandCores extends ItemBase{
 
 	public IIcon[] coresIcon = new IIcon[1];
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void registerIcons(IIconRegister icon) {
 		coresIcon[0] = icon.registerIcon(Ref.TEXTURE_PREFIX + "electricWandCore");
 	}
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public IIcon getIconFromDamage(int icon) {
 		return this.coresIcon[icon];
 	}
 
+	@Override
 	public String getUnlocalizedName(ItemStack stack) {
 		return Ref.MOD_PREFIX + Names.wandCores + "." + stack.getItemDamage();
 	}
 	
+	@Override
 	public void getSubItems(Item id, CreativeTabs tab, List list) {
 		try{
 			for (int i = 0; i < coresIcon.length; i++) {

--- a/src/main/java/theflogat/technomancy/common/items/TMItems.java
+++ b/src/main/java/theflogat/technomancy/common/items/TMItems.java
@@ -7,8 +7,6 @@ import thaumcraft.api.wands.WandRod;
 import theflogat.technomancy.lib.Ids;
 import theflogat.technomancy.lib.Names;
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class TMItems {
 

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
@@ -133,21 +133,21 @@ public abstract class TileProcessorBase extends TileTechnomancy implements ISide
 	}
 
 	protected boolean isOreDictName(ItemStack items) {
-		if(ores.contains(OreDictionary.getOreName(OreDictionary.getOreID(items)))){
-			return true;
+		int[] ids = OreDictionary.getOreIDs(items);
+		for (int id : ids) {
+			if(ores.contains(OreDictionary.getOreName(id))) return true;
 		}
 		return false;
 	}
 
 	protected Item itemFormOreDictName(ItemStack items) {
-		//for(int i : OreDictionary.getOreIDs(items)){
-		int i = OreDictionary.getOreID(items);
-		for(int j = 0; j<associatedObj.length; j++){
-			if(associatedObj[j][0] == OreDictionary.getOreName(i)){
-				return (Item) associatedObj[j][1];
+		for(int i : OreDictionary.getOreIDs(items)){
+			for(int j = 0; j<associatedObj.length; j++){
+				if(associatedObj[j][0] == OreDictionary.getOreName(i)){
+					return (Item) associatedObj[j][1];
+				}
 			}
 		}
-		//}
 		return null;
 	}
 

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
@@ -204,7 +204,7 @@ public abstract class TileProcessorBase extends TileTechnomancy implements ISide
 		NBTTagList list = compound.getTagList("ItemsTile", 10);
 
 		for(int i = 0; i < list.tagCount(); i++) {
-			NBTTagCompound item = (NBTTagCompound) list.getCompoundTagAt(i);
+			NBTTagCompound item = list.getCompoundTagAt(i);
 			int slot = item.getByte("SlotsTile");
 
 			if(slot >= 0 && slot < getSizeInventory()) {

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileProcessorBase.java
@@ -176,6 +176,7 @@ public abstract class TileProcessorBase extends TileTechnomancy implements ISide
 		compound.setBoolean("Active", isActive);		 
 	}
 	
+	@Override
 	public void writeToNBT(NBTTagCompound compound) {
 		super.writeToNBT(compound);
 		
@@ -196,6 +197,7 @@ public abstract class TileProcessorBase extends TileTechnomancy implements ISide
 		compound.setTag("ItemsTile", list);
 	}
 
+	@Override
 	public void readFromNBT(NBTTagCompound compound) {
 		super.readFromNBT(compound);
 		

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileTechnomancy.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileTechnomancy.java
@@ -14,6 +14,7 @@ public abstract class TileTechnomancy extends TileEntity {
 		return coords;
 	}
 
+	@Override
 	public void readFromNBT(NBTTagCompound nbttagcompound){
 		super.readFromNBT(nbttagcompound);
 		readCustomNBT(nbttagcompound);
@@ -21,6 +22,7 @@ public abstract class TileTechnomancy extends TileEntity {
 
 	public abstract void readCustomNBT(NBTTagCompound comp);
 
+	@Override
 	public void writeToNBT(NBTTagCompound nbttagcompound){
 		super.writeToNBT(nbttagcompound);
 		writeCustomNBT(nbttagcompound);
@@ -28,12 +30,14 @@ public abstract class TileTechnomancy extends TileEntity {
 
 	public abstract void writeCustomNBT(NBTTagCompound comp);
 
+	@Override
 	public Packet getDescriptionPacket() {
 		NBTTagCompound nbttagcompound = new NBTTagCompound();
 		writeCustomNBT(nbttagcompound);
 		return new S35PacketUpdateTileEntity(this.xCoord, this.yCoord, this.zCoord, -999, nbttagcompound);
 	}
 
+	@Override
 	public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
 		super.onDataPacket(net, pkt);
 		readCustomNBT(pkt.func_148857_g());

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
@@ -1,13 +1,11 @@
 package theflogat.technomancy.common.tiles.dynamos;
 
-import theflogat.technomancy.common.tiles.base.EnergyStorage;
 import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.handlers.compat.BloodMagic;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
@@ -19,9 +19,9 @@ public class TileBloodDynamo extends TileDynamoBase implements IFluidHandler {
 	@Override
 	public int extractFuel(int ener) {
 		if(liquid!=0){
-			float ratio = ((float) ener) / 80F;
+			float ratio = (ener) / 80F;
 			float val = 100F * ratio;
-			float fuelPerc = val / (float) Math.min(liquid, val);
+			float fuelPerc = val / Math.min(liquid, val);
 			liquid -= Math.min(liquid, val);
 			float fuel = 12F * fuelPerc;
 			return (int) fuel;

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileEssentiaDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileEssentiaDynamo.java
@@ -25,7 +25,7 @@ public class TileEssentiaDynamo extends TileDynamoBase implements IAspectContain
 		if(amount<=0 || aspect==null){
 			return 0;
 		}
-		float ratio = ((float) ener) / 80F;
+		float ratio = (ener) / 80F;
 		int val = getAspectFuel(aspect);amount -= Math.ceil(ratio);
 		if(amount<=0) {
 			amount = 0;

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileFlowerDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileFlowerDynamo.java
@@ -18,7 +18,7 @@ public class TileFlowerDynamo extends TileDynamoBase implements IManaReceiver {
 	@Override
 	public int extractFuel(int ener) {
 		if (mana == 0) return 0;
-		float ratio = ((float) ener) / 80F;
+		float ratio = (ener) / 80F;
 		int val = (int) (20 * ratio);
 		float fuel = (float) val / (float) Math.min(mana, val);mana -= Math.min(mana, val);
 		return (int) (((float)10*20)*fuel);

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
@@ -5,10 +5,7 @@ import java.util.ArrayList;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.aspects.IAspectContainer;
 import thaumcraft.api.nodes.INode;
-import theflogat.technomancy.common.tiles.base.EnergyStorage;
 import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 
 public class TileNodeDynamo extends TileDynamoBase{

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
@@ -19,7 +19,7 @@ public class TileNodeDynamo extends TileDynamoBase{
 
 	@Override
 	public int extractFuel(int ener) {
-		float ratio = ((float) ener) / 80F;
+		float ratio = (ener) / 80F;
 		if(((int)ratio)>amount)
 			return 0;
 		amount -= ((int)ratio);

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
@@ -40,8 +40,7 @@ public class TileNodeDynamo extends TileDynamoBase{
 					Aspect[] as = node.getAspects().getAspects();
 					for (int i = 0; i < as.length; i++) {
 						Aspect aspect = as[i];
-						int nodeAmount = node.containerContains(aspect);
-						if(nodeAmount!= 1 && amount < 16){
+						if(node.getAspects().getAmount(aspect) > 1 && amount < 16){
 							if(node.takeFromContainer(aspect, 1) ) {
 								amount += 1;
 							}

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
@@ -70,11 +70,13 @@ public class TileNodeDynamo extends TileDynamoBase{
 		return l;
 	}
 
+	@Override
 	public void readCustomNBT(NBTTagCompound comp) {
 		super.readCustomNBT(comp);
 		this.amount = comp.getShort("Amount");
 	}
 
+	@Override
 	public void writeCustomNBT(NBTTagCompound comp) {
 		super.writeCustomNBT(comp);
 		comp.setShort("Amount", (short)amount);

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
@@ -37,6 +37,7 @@ public class TileEldritchConsumer extends TileMachineBase implements IAspectCont
 		public int id;
 		public String chat;
 		
+		@Override
 		public String toString() {return chat;};
 		
 		Range(int range, int height, int id, String chat){

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
@@ -50,7 +50,7 @@ public class TileElectricBellows extends TileMachineBase {
 						if(al == null || al.size() == 0) {
 							return;
 						}
-						if(((int)Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace)) <= 2 &&
+						if((Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace)) <= 2 &&
 								((AspectList)Thaumcraft.TileAlchemyFurnace.getField("aspects").get(furnace)).visSize() + al.visSize() < 50) {
 							Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").set(furnace, 80);
 							extractEnergy(baseCost * 6, false);
@@ -59,9 +59,9 @@ public class TileElectricBellows extends TileMachineBase {
 				}
 				if(Thaumcraft.TileArcaneFurnace.isInstance(furnace)) {
 					if(extractEnergy(baseCost, true) == baseCost) {
-						if(((int)Thaumcraft.TileArcaneFurnace.getField("furnaceCookTime").getInt(furnace)) > 6) {
+						if((Thaumcraft.TileArcaneFurnace.getField("furnaceCookTime").getInt(furnace)) > 6) {
 							Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").set(furnace, 
-									((int)Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace))-6);
+									(Thaumcraft.TileAlchemyFurnace.getField("furnaceBurnTime").getInt(furnace))-6);
 							extractEnergy(baseCost, false);
 						}
 					}

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
@@ -63,15 +63,15 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 				if(tile == null) {
 					return;
 				}
-				if(!((boolean)Thaumcraft.TileInfusionMatrix.getField("crafting").getBoolean(tile))) {
+				if(!Thaumcraft.TileInfusionMatrix.getField("crafting").getBoolean(tile)) {
 					this.stabilize = true;
 				}	
-				if(((int)Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) > 0 && stabilize) {
+				if((Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) > 0 && stabilize) {
 					for(int i = 0; i < 5; i++) {					
 						if(amount >= 5 && (tank.getCapacity() - tank.getFluidAmount()) >= 200 && stabilize) {
 							takeFromContainer(aspect, 5);
 							Thaumcraft.TileInfusionMatrix.getField("instability").set(tile,
-									((int)Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) - 1);
+									(Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) - 1);
 							tank.fill(FluidRegistry.getFluidStack(Thaumcraft.FLUXGOO.getName(), 200), true);
 						}else{
 							break;

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
@@ -21,7 +21,6 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	int amount = 0;
 	int maxAmount = 32;
-	Aspect aspect;
 	public FluidTank tank = new FluidTank(1000);	
 	Aspect aspectSuction;
 	boolean stabilize = true;
@@ -29,19 +28,15 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public void writeCustomNBT(NBTTagCompound compound) {
-		compound.setInteger("Amount", amount);
+		compound.setInteger("AspectAmount", amount);
 		compound.setBoolean("Stabilize", stabilize);
-		if (aspect != null) {
-			compound.setString("Aspect", aspect.getTag());
-		}	
 		compound.setBoolean("Placed", placed);
 		tank.writeToNBT(compound);
 	}
 
 	@Override
 	public void readCustomNBT(NBTTagCompound compound) {
-		amount = compound.getInteger("Amount");
-		aspect = Aspect.getAspect(compound.getString("Aspect"));
+		amount = compound.getInteger("AspectAmount");
 		stabilize = compound.getBoolean("Stabilize");
 		placed = compound.getBoolean("Placed");
 		tank = new FluidTank(1000);
@@ -54,7 +49,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 		try{
 			if(!worldObj.isRemote) {
 				TileEntity tile = null;
-				if ((!worldObj.isRemote) && (++count % 10 == 0)) {
+				if (!worldObj.isRemote && ++count % 10 == 0) {
 					if(amount < maxAmount) {
 						fill();
 					}
@@ -66,10 +61,10 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 				if(!Thaumcraft.TileInfusionMatrix.getField("crafting").getBoolean(tile)) {
 					this.stabilize = true;
 				}	
-				if((Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) > 0 && stabilize) {
+				if(Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile) > 0 && stabilize) {
 					for(int i = 0; i < 5; i++) {					
 						if(amount >= 5 && (tank.getCapacity() - tank.getFluidAmount()) >= 200 && stabilize) {
-							takeFromContainer(aspect, 5);
+							takeFromContainer(Aspect.ORDER, 5);
 							Thaumcraft.TileInfusionMatrix.getField("instability").set(tile,
 									(Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) - 1);
 							tank.fill(FluidRegistry.getFluidStack(Thaumcraft.FLUXGOO.getName(), 200), true);
@@ -106,15 +101,9 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 			if (!ic.canOutputTo(ForgeDirection.DOWN)) {
 				return;
 			}
-			Aspect ta = null;
-			if ((this.aspect != null) && (this.amount > 0)) {
-				ta = this.aspect;
-			} else if ((ic.getEssentiaAmount(ForgeDirection.DOWN) > 0) && 
-					(ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP)) && (getSuctionAmount(ForgeDirection.UP) >= ic.getMinimumSuction())) {
-				ta = ic.getEssentiaType(ForgeDirection.DOWN);
-			}
-			if ((ta != null) && (ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP))) {
-				addToContainer(ta, ic.takeEssentia(ta, 1, ForgeDirection.DOWN));
+			if (ic.getEssentiaAmount(ForgeDirection.DOWN) > 0 && ic.getEssentiaType(ForgeDirection.DOWN) == Aspect.ORDER &&
+					ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP) && getSuctionAmount(ForgeDirection.UP) >= ic.getMinimumSuction()) {
+				addToContainer(Aspect.ORDER, ic.takeEssentia(Aspect.ORDER, 1, ForgeDirection.DOWN));
 			}
 		}
 	}
@@ -122,19 +111,18 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 	@Override
 	public AspectList getAspects()  {
 		AspectList al = new AspectList();
-		if ((this.aspect != null) && (this.amount > 0)) {
-			al.add(this.aspect, this.amount);
+		if (this.amount > 0) {
+			al.add(Aspect.ORDER, this.amount);
 		}
 		return al;
-	}	  
-
+	}
+	
 	@Override
 	public int addToContainer(Aspect tag, int amount)  {
 		if (amount == 0) {
 			return amount;
 		}
-		if (((this.amount < this.maxAmount) && (tag == this.aspect)) || (this.amount == 0)) {
-			this.aspect = tag;
+		if (this.amount < this.maxAmount && tag == Aspect.ORDER) {
 			int added = Math.min(amount, this.maxAmount - this.amount);
 			this.amount += added;
 			amount -= added;
@@ -145,12 +133,8 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean takeFromContainer(Aspect tag, int amount)  {
-		if ((this.amount >= amount) && (tag == this.aspect)) {
+		if (this.amount >= amount && tag == Aspect.ORDER) {
 			this.amount -= amount;
-			if (this.amount <= 0) {
-				this.aspect = null;
-				this.amount = 0;
-			}
 			this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
 			return true;
 		}
@@ -159,7 +143,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean doesContainerContainAmount(Aspect tag, int amt) {
-		if ((this.amount >= amt) && (tag == this.aspect)) {
+		if (amount >= amt && tag == Aspect.ORDER) {
 			return true;
 		}
 		return false;
@@ -167,10 +151,11 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean doesContainerContain(AspectList ot)  {
-		for (Aspect tt : ot.getAspects()) {
-			if ((this.amount > 0) && (tt == this.aspect)) {
-				return true;
-			}
+		if (ot.size() > 1) {
+			return false;
+		}
+		if (ot.getAspects()[1] == Aspect.ORDER && this.amount >= ot.getAmount(Aspect.ORDER)) {
+			return true;
 		}
 		return false;
 	}
@@ -231,9 +216,9 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 	@Override
 	public Aspect getSuctionType(ForgeDirection face) {
 		if(this.amount < this.maxAmount) {
-			this.aspectSuction = Aspect.ORDER;
+			return Aspect.ORDER;
 		}
-		return this.aspectSuction;
+		return null;
 	}
 
 	@Override
@@ -251,7 +236,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public Aspect getEssentiaType(ForgeDirection face) {
-		return this.aspect;
+		return amount > 0 ? Aspect.ORDER : null;
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileNodeGenerator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileNodeGenerator.java
@@ -249,6 +249,7 @@ public class TileNodeGenerator extends TileMachineBase implements IEssentiaTrans
 		return -1;
 	}
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public AxisAlignedBB getRenderBoundingBox() {
 		if (this.facing == 1 || this.facing == 3) {

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileNodeGenerator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileNodeGenerator.java
@@ -15,11 +15,9 @@ import thaumcraft.api.aspects.IEssentiaTransport;
 import thaumcraft.api.nodes.INode;
 import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.api.nodes.NodeType;
-import thaumcraft.api.wands.IWandable;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.handlers.compat.Thaumcraft;
 import theflogat.technomancy.handlers.util.MathHelper;
-import cofh.api.energy.EnergyStorage;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTeslaCoil.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTeslaCoil.java
@@ -79,9 +79,9 @@ public class TileTeslaCoil extends TileTechnomancy {
 								if(source.takeFromContainer(aspect, 1)) {
 									if(Conf.fancy) {
 										if(this!=null && tile!=null && color>0 && source!=null) {
-											Technomancy.proxy.essentiaTrail(worldObj, (double)xCoord + 0.5D, (double)yCoord + 0.5D,
-													(double)zCoord + 0.5D, (double)(tile.xCoord) + 0.5D, (double)(tile.yCoord) + 0.5D,
-													(double)(tile.zCoord) + 0.5D, color);
+											Technomancy.proxy.essentiaTrail(worldObj, xCoord + 0.5D, yCoord + 0.5D,
+													zCoord + 0.5D, (tile.xCoord) + 0.5D, (tile.yCoord) + 0.5D,
+													(tile.zCoord) + 0.5D, color);
 										}
 									}
 								} else {

--- a/src/main/java/theflogat/technomancy/handlers/compat/BloodMagic.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/BloodMagic.java
@@ -14,9 +14,9 @@ public class BloodMagic {
 
 	public static void init() {
 		try{
-			Class BMM = Class.forName("WayofTime.alchemicalWizardry.AlchemicalWizardry");
+			Class<?> BMM = Class.forName("WayofTime.alchemicalWizardry.AlchemicalWizardry");
 			lifeEssenceFluid = (Fluid) BMM.getField("lifeEssenceFluid").get(BMM);
-			Class BMI = Class.forName("WayofTime.alchemicalWizardry.ModItems");
+			Class<?> BMI = Class.forName("WayofTime.alchemicalWizardry.ModItems");
 			divinationSigil = (Item) BMI.getField("divinationSigil").get(BMI);
 			bucketLife = (Item) BMI.getField("bucketLife").get(BMI);
 			System.out.println("Technomancy: Blood Magic Module Activated");

--- a/src/main/java/theflogat/technomancy/handlers/compat/Botania.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/Botania.java
@@ -15,7 +15,7 @@ public class Botania {
 
 	public static void init() {
 		try {
-			Class CP = Class.forName("vazkii.botania.common.core.proxy.CommonProxy");
+			Class<?> CP = Class.forName("vazkii.botania.common.core.proxy.CommonProxy");
 			for(Method method : CP.getMethods()){
 				if(method.getName().equalsIgnoreCase("sparkleFX")){
 					sparkle = method;
@@ -27,7 +27,7 @@ public class Botania {
 
 	public static void client(){
 		try{
-			Class HUD = Class.forName("vazkii.botania.client.core.handler.HUDHandler");
+			Class<?> HUD = Class.forName("vazkii.botania.client.core.handler.HUDHandler");
 			for(Method method : HUD.getMethods()){
 				if(method.getName().equalsIgnoreCase("drawSimpleManaHUD")){
 					drawHUD = method;
@@ -45,7 +45,7 @@ public class Botania {
 
 	public static void sparkle(World world, double d, double d1, double f, Random r){
 		try {
-			Class BOM = Class.forName("vazkii.botania.common.Botania");
+			Class<?> BOM = Class.forName("vazkii.botania.common.Botania");
 			sparkle.invoke(BOM.getField("proxy").get(BOM), world, d, d1, f, r.nextFloat(), r.nextFloat(), 1.0F, r.nextFloat() * 4, 10);
 		} catch (Exception e) {Conf.ex(e);}
 	}

--- a/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
@@ -317,7 +317,6 @@ public class Thaumcraft {
 
 	public static void dropItems(World world, int x, int y, int z) {
 		Random rand = new Random();
-		int md = world.getBlockMetadata(x, y, z);
 		TileEntity tileEntity = world.getTileEntity(x, y, z);
 		if (!(tileEntity instanceof IInventory)) {
 			return;

--- a/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
@@ -44,15 +44,15 @@ public class Thaumcraft {
 //	public static Constructor<?> ResearchPageIArcRecipe;
 //	public static Constructor<?> ResearchPageIInfRecipe;
 
-	public static Class TileAlchemyFurnace;
-	public static Class TileArcaneFurnace;
-	public static Class TileInfusionMatrix;
-	public static Class TileNode;
-	public static Class TileMirrorEssentia;
-	public static Class TileTube;
-	public static Class TileTable;
-	public static Class TileResearchTable;
-	public static Class ItemWandCasting;
+	public static Class<?> TileAlchemyFurnace;
+	public static Class<?> TileArcaneFurnace;
+	public static Class<?> TileInfusionMatrix;
+	public static Class<?> TileNode;
+	public static Class<?> TileMirrorEssentia;
+	public static Class<?> TileTube;
+	public static Class<?> TileTable;
+	public static Class<?> TileResearchTable;
+	public static Class<?> ItemWandCasting;
 //	public static Class ResearchPage;
 //	public static Class ResearchPageArr;
 //	public static Class CrucibleRecipe;
@@ -133,12 +133,12 @@ public class Thaumcraft {
 
 	public static void init() {
 		try{
-			Class THW = Class.forName("thaumcraft.common.lib.world.ThaumcraftWorldGenerator");
+			Class<?> THW = Class.forName("thaumcraft.common.lib.world.ThaumcraftWorldGenerator");
 			biomeMagicalForest = (BiomeGenBase) THW.getField("biomeMagicalForest").get(THW);
 			biomeTaint = (BiomeGenBase) THW.getField("biomeTaint").get(THW);
 			biomeEerie = (BiomeGenBase) THW.getField("biomeEerie").get(THW);
 
-			Class TCB = Class.forName("thaumcraft.common.config.ConfigBlocks");
+			Class<?> TCB = Class.forName("thaumcraft.common.config.ConfigBlocks");
 			FLUXGOO = (Fluid)TCB.getField("FLUXGOO").get(TCB);
 			blockCosmeticSolid = (Block)TCB.getField("blockCosmeticSolid").get(TCB);
 			blockMetalDevice = (Block)TCB.getField("blockMetalDevice").get(TCB);
@@ -148,7 +148,7 @@ public class Thaumcraft {
 			blockCustomPlant = (Block)TCB.getField("blockCustomPlant").get(TCB);
 			blockWoodenDevice = (Block)TCB.getField("blockWoodenDevice").get(TCB);
 
-			Class TCI = Class.forName("thaumcraft.common.config.ConfigItems");
+			Class<?> TCI = Class.forName("thaumcraft.common.config.ConfigItems");
 			itemResource = (Item)TCI.getField("itemResource").get(TCI);
 			itemEssence = (Item)TCI.getField("itemEssence").get(TCI);
 			itemNugget = (Item)TCI.getField("itemNugget").get(TCI);
@@ -174,23 +174,23 @@ public class Thaumcraft {
 				}
 			}
 
-			Class TCH = Class.forName("thaumcraft.common.lib.crafting.ThaumcraftCraftingManager");
+			Class<?> TCH = Class.forName("thaumcraft.common.lib.crafting.ThaumcraftCraftingManager");
 			for(Method method : TCH.getMethods()){
 				if(method.getName().equalsIgnoreCase("getObjectTags")){getObjectTags = method;
 				} else if(method.getName().equalsIgnoreCase("getBonusTags")){getBonusTags = method;}
 			}
 
-			Class TBH = Class.forName("thaumcraft.common.lib.world.biomes.BiomeHandler");
+			Class<?> TBH = Class.forName("thaumcraft.common.lib.world.biomes.BiomeHandler");
 			for(Method method : TBH.getMethods()){
 				if(method.getName().equalsIgnoreCase("getRandomBiomeTag")){getRandomBiomeTag = method;}
 			}
 
-			Class TWG = Class.forName("thaumcraft.common.lib.world.ThaumcraftWorldGenerator");
+			Class<?> TWG = Class.forName("thaumcraft.common.lib.world.ThaumcraftWorldGenerator");
 			for(Method method : TWG.getMethods()){
 				if(method.getName().equalsIgnoreCase("createNodeAt")){createNodeAt = method;}
 			}
 
-			Class TEH = Class.forName("thaumcraft.common.lib.events.EssentiaHandler");
+			Class<?> TEH = Class.forName("thaumcraft.common.lib.events.EssentiaHandler");
 			for(Method method : TEH.getMethods()){
 				if(method.getName().equalsIgnoreCase("drainEssentia")){drainEssentia = method;}
 			}
@@ -255,29 +255,30 @@ public class Thaumcraft {
 //			ResearchPageIArcRecipe = ResearchPage.getConstructor(ArcaneRecipe);
 //			ResearchPageIInfRecipe = ResearchPage.getConstructor(InfusionRecipe);
 
-			Class Conf = Class.forName("thaumcraft.common.config.Config");
+			Class<?> Conf = Class.forName("thaumcraft.common.config.Config");
 			crooked = Conf.getField("crooked").getBoolean(Conf);
 			
-			Class BlockJar = Class.forName("thaumcraft.common.blocks.BlockJar");
+			Class<?> BlockJar = Class.forName("thaumcraft.common.blocks.BlockJar");
 			iconLiquid = (IIcon)BlockJar.getField("iconLiquid").get(Thaumcraft.blockJar);
 
 			System.out.println("Technomancy: Thaumcraft Module Activated");
 		}catch(Exception e){th = false;System.out.println("Technomancy: Failed to load Thaumcraft Module");Conf.ex(e);}
 	}
 	
+	@SuppressWarnings("unchecked")
 	public static void client() {
 		try{
-			Class TPR = Class.forName("thaumcraft.client.ClientProxy");
+			Class<?> TPR = Class.forName("thaumcraft.client.ClientProxy");
 			for(Method method : TPR.getMethods()){
 				if(method.getName().equalsIgnoreCase("wispFX3")){wispFX3 = method;}
 			}
 
-			Class FXEssentiaTrail = Class.forName("thaumcraft.client.fx.particles.FXEssentiaTrail");
-			FXEssentiaTrailConst = FXEssentiaTrail.getConstructor(World.class, double.class, double.class, double.class, double.class,
+			Class<?> FXEssentiaTrail = Class.forName("thaumcraft.client.fx.particles.FXEssentiaTrail");
+			FXEssentiaTrailConst = (Constructor<? extends EntityFX>)FXEssentiaTrail.getConstructor(World.class, double.class, double.class, double.class, double.class,
 					double.class, double.class, int.class, int.class, float.class);
 
-			Class FXLightningBolt = Class.forName("thaumcraft.client.fx.bolt.FXLightningBolt");
-			FXLightningBoltConst = FXLightningBolt.getConstructor(World.class, double.class, double.class, double.class, double.class,
+			Class<?> FXLightningBolt = Class.forName("thaumcraft.client.fx.bolt.FXLightningBolt");
+			FXLightningBoltConst = (Constructor<? extends EntityFX>)FXLightningBolt.getConstructor(World.class, double.class, double.class, double.class, double.class,
 					double.class, double.class, long.class, int.class, float.class);
 			for(Method method : FXLightningBolt.getMethods()){
 				if(method.getName().equalsIgnoreCase("defaultFractal")){defaultFractal = method;
@@ -287,7 +288,7 @@ public class Thaumcraft {
 				}
 			}
 			
-			Class UtilsFX = Class.forName("thaumcraft.client.lib.UtilsFX");
+			Class<?> UtilsFX = Class.forName("thaumcraft.client.lib.UtilsFX");
 
 			for(Method method : UtilsFX.getMethods()){
 				if(method.getName().equalsIgnoreCase("renderQuadCenteredFromTexture") && method.getParameterTypes()[0]==String.class){
@@ -296,13 +297,13 @@ public class Thaumcraft {
 				}
 			}
 			
-			Class JR = Class.forName("thaumcraft.client.renderers.tile.TileJarRenderer");
+			Class<?> JR = Class.forName("thaumcraft.client.renderers.tile.TileJarRenderer");
 			for(Method method : JR.getMethods()){
 				if(method.getName().equalsIgnoreCase("renderLiquid")){renderLiquid = method;
 				//}else if(method.getName().equalsIgnoreCase("drawTag")){drawTag = method;
 				}
 			}
-			JarRenderConst = JR.getConstructor();
+			JarRenderConst = (Constructor<? extends TileEntitySpecialRenderer>)JR.getConstructor();
 			System.out.println("Technomancy: Thaumcraft Client-Side Module loaded");
 		}catch(Exception e){th = false;System.out.println("Technomancy: Failed to load Thaumcraft Client-Side Module");Conf.ex(e);}
 	}
@@ -310,7 +311,7 @@ public class Thaumcraft {
 	public static void wispFX3(World worldObj, double posX, double posY, double posZ, double posX2, double posY2, double posZ2,
 			float size, int type, boolean shrink, float gravity) {
 		try{
-			Class TH = Class.forName("thaumcraft.common.Thaumcraft");
+			Class<?> TH = Class.forName("thaumcraft.common.Thaumcraft");
 			wispFX3.invoke(TH.getField("proxy").get(TH), worldObj, posX, posY, posZ, posX2, posY2, posZ2, size, type, shrink, gravity);
 		}catch(Exception e){e.printStackTrace();}
 	}
@@ -368,7 +369,7 @@ public class Thaumcraft {
 		AspectList ot = null;
 		try {
 			if (getObjectTags == null) {
-				Class fake = Class.forName("thaumcraft.common.lib.crafting.ThaumcraftCraftingManager");
+				Class<?> fake = Class.forName("thaumcraft.common.lib.crafting.ThaumcraftCraftingManager");
 				getObjectTags = fake.getMethod("getObjectTags", new Class[] { ItemStack.class });
 			}
 			ot = (AspectList)getObjectTags.invoke(null, is);

--- a/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
@@ -257,7 +257,7 @@ public class Thaumcraft {
 //			ResearchPageIInfRecipe = ResearchPage.getConstructor(InfusionRecipe);
 
 			Class Conf = Class.forName("thaumcraft.common.config.Config");
-			crooked = (boolean)Conf.getField("crooked").getBoolean(Conf);
+			crooked = Conf.getField("crooked").getBoolean(Conf);
 			
 			Class BlockJar = Class.forName("thaumcraft.common.blocks.BlockJar");
 			iconLiquid = (IIcon)BlockJar.getField("iconLiquid").get(Thaumcraft.blockJar);

--- a/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/Thaumcraft.java
@@ -21,7 +21,6 @@ import net.minecraftforge.fluids.Fluid;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectContainer;
-import thaumcraft.api.aspects.IAspectSource;
 import thaumcraft.api.aspects.IEssentiaTransport;
 import theflogat.technomancy.lib.Conf;
 

--- a/src/main/java/theflogat/technomancy/handlers/compat/ThermalExpansion.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/ThermalExpansion.java
@@ -1,10 +1,7 @@
 package theflogat.technomancy.handlers.compat;
 
-import java.lang.reflect.Method;
-
 import theflogat.technomancy.lib.Conf;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 public class ThermalExpansion {

--- a/src/main/java/theflogat/technomancy/handlers/compat/ThermalExpansion.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/ThermalExpansion.java
@@ -43,13 +43,13 @@ public class ThermalExpansion {
 
 	public static void init(){
 		try{
-			Class TEI = Class.forName("thermalexpansion.item.TEItems");
+			Class<?> TEI = Class.forName("thermalexpansion.item.TEItems");
 			powerCoilElectrum = (ItemStack) TEI.getField("powerCoilElectrum").get(TEI);
 			capacitorResonant = (ItemStack) TEI.getField("capacitorResonant").get(TEI);
 			powerCoilSilver = (ItemStack) TEI.getField("powerCoilSilver").get(TEI);
 			powerCoilGold = (ItemStack) TEI.getField("powerCoilGold").get(TEI);
 			
-			Class TFI = Class.forName("thermalfoundation.item.TFItems");
+			Class<?> TFI = Class.forName("thermalfoundation.item.TFItems");
 			ingotSilver = (ItemStack) TFI.getField("ingotSilver").get(TFI);
 			ingotLead = (ItemStack) TFI.getField("ingotLead").get(TFI);
 			ingotNickel = (ItemStack) TFI.getField("ingotNickel").get(TFI);
@@ -57,12 +57,12 @@ public class ThermalExpansion {
 			ingotCopper = (ItemStack) TFI.getField("ingotCopper").get(TFI);
 			ingotTin = (ItemStack) TFI.getField("ingotTin").get(TFI);
 			
-			Class TEB = Class.forName("thermalexpansion.block.TEBlocks");
+			Class<?> TEB = Class.forName("thermalexpansion.block.TEBlocks");
 			blockCell = (Block) TEB.getField("blockCell").get(TEB);
 			blockDynamo = (Block) TEB.getField("blockDynamo").get(TEB);
 			blockTank = (Block) TEB.getField("blockTank").get(TEB);
 			
-			Class TBM = Class.forName("thermalexpansion.block.machine.BlockMachine");
+			Class<?> TBM = Class.forName("thermalexpansion.block.machine.BlockMachine");
 			pulverizer = (ItemStack) TBM.getField("pulverizer").get(TBM);
 			sawmill = (ItemStack) TBM.getField("sawmill").get(TBM);
 			smelter = (ItemStack) TBM.getField("smelter").get(TBM);
@@ -74,7 +74,7 @@ public class ThermalExpansion {
 			assembler = (ItemStack) TBM.getField("assembler").get(TBM);
 			charger = (ItemStack) TBM.getField("charger").get(TBM);
 			
-			Class TBF = Class.forName("thermalexpansion.block.simple.BlockFrame");
+			Class<?> TBF = Class.forName("thermalexpansion.block.simple.BlockFrame");
 			frameMachineBasic = (ItemStack) TBF.getField("frameMachineBasic").get(TBF);
 			frameTesseractFull = (ItemStack) TBF.getField("frameTesseractFull").get(TBF);
 			frameCellBasic = (ItemStack) TBF.getField("frameCellBasic").get(TBF);

--- a/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJar.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJar.java
@@ -18,10 +18,12 @@ public class TileJar extends TileThaumcraft{
 	protected int spazattack = 0;
 	protected boolean canSpaz = false;
 
+	@Override
 	public boolean canUpdate(){
 		return true;
 	}
 
+	@Override
 	public void updateEntity(){
 		super.updateEntity();
 

--- a/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJar.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJar.java
@@ -9,7 +9,6 @@
 package theflogat.technomancy.handlers.compat.thaumcraft;
 
 import java.util.Random;
-import net.minecraft.world.World;
 
 public class TileJar extends TileThaumcraft{
 	public float wobblex = 0.0F;

--- a/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJarFillable.java
+++ b/src/main/java/theflogat/technomancy/handlers/compat/thaumcraft/TileJarFillable.java
@@ -28,12 +28,14 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 	public boolean forgeLiquid = false;
 	public int lid = 0;
 
+	@Override
 	public boolean canUpdate()
 	{
 		return true;
 	}
 
 
+	@Override
 	public void readCustomNBT(NBTTagCompound nbttagcompound)
 	{
 		aspect = Aspect.getAspect(nbttagcompound.getString("Aspect"));
@@ -43,6 +45,7 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 	}
 
 
+	@Override
 	public void writeCustomNBT(NBTTagCompound nbttagcompound)
 	{
 		if (aspect != null) nbttagcompound.setString("Aspect", aspect.getTag());
@@ -53,6 +56,7 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 
 
 
+	@Override
 	public AspectList getAspects()
 	{
 		AspectList al = new AspectList();
@@ -62,9 +66,11 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 
 
 
+	@Override
 	public void setAspects(AspectList aspects) {}
 
 
+	@Override
 	public int addToContainer(Aspect tt, int am)
 	{
 		if (am == 0) return am;
@@ -79,6 +85,7 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 		return am;
 	}
 
+	@Override
 	public boolean takeFromContainer(Aspect tt, int am)
 	{
 		if ((amount >= am) && (tt == aspect)) {
@@ -93,18 +100,21 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 		return false;
 	}
 
+	@Override
 	public boolean takeFromContainer(AspectList ot)
 	{
 		return false;
 	}
 
 
+	@Override
 	public boolean doesContainerContainAmount(Aspect tag, int amt)
 	{
 		if ((amount >= amt) && (tag == aspect)) return true;
 		return false;
 	}
 
+	@Override
 	public boolean doesContainerContain(AspectList ot)
 	{
 		for (Aspect tt : ot.getAspects()) {
@@ -113,11 +123,13 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 		return false;
 	}
 
+	@Override
 	public int containerContains(Aspect tag)
 	{
 		return 0;
 	}
 
+	@Override
 	public boolean doesContainerAccept(Aspect tag)
 	{
 		return aspectFilter != null ? tag.equals(aspectFilter) : true;
@@ -126,39 +138,47 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 
 
 
+	@Override
 	public boolean isConnectable(ForgeDirection face)
 	{
 		return face == ForgeDirection.UP;
 	}
 
+	@Override
 	public boolean canInputFrom(ForgeDirection face)
 	{
 		return face == ForgeDirection.UP;
 	}
 
+	@Override
 	public boolean canOutputTo(ForgeDirection face)
 	{
 		return face == ForgeDirection.UP;
 	}
 
 
+	@Override
 	public void setSuction(Aspect aspect, int amount) {}
 
+	@Override
 	public boolean renderExtendedTube()
 	{
 		return true;
 	}
 
+	@Override
 	public int getMinimumSuction()
 	{
 		return aspectFilter != null ? 64 : 32;
 	}
 
+	@Override
 	public Aspect getSuctionType(ForgeDirection loc)
 	{
 		return aspectFilter != null ? aspectFilter : aspect;
 	}
 
+	@Override
 	public int getSuctionAmount(ForgeDirection loc)
 	{
 		if (amount < maxAmount) {
@@ -172,21 +192,25 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 	}
 
 
+	@Override
 	public Aspect getEssentiaType(ForgeDirection loc)
 	{
 		return aspect;
 	}
 
+	@Override
 	public int getEssentiaAmount(ForgeDirection loc)
 	{
 		return amount;
 	}
 
+	@Override
 	public int takeEssentia(Aspect aspect, int amount, ForgeDirection dir)
 	{
 		return takeFromContainer(aspect, amount) ? amount : 0;
 	}
 
+	@Override
 	public int addEssentia(Aspect aspect, int amount, ForgeDirection dir)
 	{
 		return amount - addToContainer(aspect, amount);
@@ -194,6 +218,7 @@ public class TileJarFillable extends TileJar implements IAspectSource, IEssentia
 
 	int count = 0;
 
+	@Override
 	public void updateEntity()
 	{
 		super.updateEntity();

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -471,7 +471,7 @@ public class CraftingHandler {
 		try{
 			if(ThermalExpansion.te){
 				//ManaInfusion
-				RecipeManaInfusion manaCoilRecipe = BotaniaAPI.registerManaInfusionRecipe(new ItemStack(TMItems.itemBO, 1, 0), ThermalExpansion.powerCoilSilver, 3000);		
+				BotaniaAPI.registerManaInfusionRecipe(new ItemStack(TMItems.itemBO, 1, 0), ThermalExpansion.powerCoilSilver, 3000);		
 
 				//Normal Recipes
 				oreDictRecipe(new ItemStack(TMItems.itemBO, 1, 1),
@@ -499,8 +499,7 @@ public class CraftingHandler {
 					'A', new ItemStack(Items.redstone)				});
 			}else{
 				//ManaInfusion
-				RecipeManaInfusion manaCoilRecipe = BotaniaAPI.registerManaInfusionRecipe(new ItemStack(TMItems.itemBO, 1, 0),
-						new ItemStack(Items.redstone), 3000);		
+				BotaniaAPI.registerManaInfusionRecipe(new ItemStack(TMItems.itemBO, 1, 0), new ItemStack(Items.redstone), 3000);		
 
 				//Normal Recipes
 				oreDictRecipe(new ItemStack(TMItems.itemBO, 1, 1),

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -529,6 +529,7 @@ public class CraftingHandler {
 		}catch(Exception e){e.printStackTrace();}
 	}
 
+	@SuppressWarnings("unchecked")
 	static IRecipe oreDictRecipe(ItemStack res, Object[] params) {
 		IRecipe rec = new ShapedOreRecipe(res, params);
 		CraftingManager.getInstance().getRecipeList().add(rec);

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -255,21 +255,21 @@ public class CraftingHandler {
 
 				//Wand Recipes
 				ItemStack electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
-				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("thaumium"));
-				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, WandCap.caps.get("thaumium"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, WandRod.rods.get("electric"));
 				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 60).add(Aspect.ORDER, 60)
 						.add(Aspect.EARTH, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60).add(Aspect.ENTROPY, 60), 
 						new Object[]{"  C", " R ", "C  ", 
-					Character.valueOf('C'), ((WandCap)WandCap.caps.get("thaumium")).getItem(), 
-					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+					Character.valueOf('C'), WandCap.caps.get("thaumium").getItem(), 
+					Character.valueOf('R'), WandRod.rods.get("electric").getItem()});
 				electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
-				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("void"));
-				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, WandCap.caps.get("void"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, WandRod.rods.get("electric"));
 				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 87).add(Aspect.ORDER, 87)
 						.add(Aspect.EARTH, 87).add(Aspect.FIRE, 87).add(Aspect.WATER, 87).add(Aspect.ENTROPY, 87), 
 						new Object[]{"  C", " R ", "C  ", 
-					Character.valueOf('C'), ((WandCap)WandCap.caps.get("void")).getItem(), 
-					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+					Character.valueOf('C'), WandCap.caps.get("void").getItem(), 
+					Character.valueOf('R'), WandRod.rods.get("electric").getItem()});
 			}else{
 				//Infusion Recipes
 				ResearchHandler.recipes.put("NodeGenerator", ThaumcraftApi.addInfusionCraftingRecipe("NODEGENERATOR",
@@ -395,21 +395,21 @@ public class CraftingHandler {
 
 				//Wand Recipes
 				ItemStack electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
-				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("thaumium"));
-				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, WandCap.caps.get("thaumium"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, WandRod.rods.get("electric"));
 				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 60).add(Aspect.ORDER, 60)
 						.add(Aspect.EARTH, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60).add(Aspect.ENTROPY, 60), 
 						new Object[]{"  C", " R ", "C  ", 
-					Character.valueOf('C'), ((WandCap)WandCap.caps.get("thaumium")).getItem(), 
-					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+					Character.valueOf('C'), WandCap.caps.get("thaumium").getItem(), 
+					Character.valueOf('R'), WandRod.rods.get("electric").getItem()});
 				electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
-				Thaumcraft.setCap.invoke(electric.getItem(), electric, (WandCap)WandCap.caps.get("void"));
-				Thaumcraft.setRod.invoke(electric.getItem(), electric, (WandRod)WandRod.rods.get("electric"));
+				Thaumcraft.setCap.invoke(electric.getItem(), electric, WandCap.caps.get("void"));
+				Thaumcraft.setRod.invoke(electric.getItem(), electric, WandRod.rods.get("electric"));
 				ThaumcraftApi.addArcaneCraftingRecipe("ENERGIZEDWAND", electric, new AspectList().add(Aspect.AIR, 87).add(Aspect.ORDER, 87)
 						.add(Aspect.EARTH, 87).add(Aspect.FIRE, 87).add(Aspect.WATER, 87).add(Aspect.ENTROPY, 87), 
 						new Object[]{"  C", " R ", "C  ", 
-					Character.valueOf('C'), ((WandCap)WandCap.caps.get("void")).getItem(), 
-					Character.valueOf('R'), ((WandRod)WandRod.rods.get("electric")).getItem()});
+					Character.valueOf('C'), WandCap.caps.get("void").getItem(), 
+					Character.valueOf('R'), WandRod.rods.get("electric").getItem()});
 			}
 		}catch(Exception e){e.printStackTrace();}
 	}

--- a/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/CraftingHandler.java
@@ -22,7 +22,6 @@ import theflogat.technomancy.handlers.compat.ThermalExpansion;
 import theflogat.technomancy.handlers.util.CompareItemStack;
 import theflogat.technomancy.handlers.util.ItemHelper;
 import vazkii.botania.api.BotaniaAPI;
-import vazkii.botania.api.recipe.RecipeManaInfusion;
 import WayofTime.alchemicalWizardry.api.altarRecipeRegistry.AltarRecipeRegistry;
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.registry.GameRegistry;

--- a/src/main/java/theflogat/technomancy/handlers/handlers/PacketHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/PacketHandler.java
@@ -1,10 +1,5 @@
 package theflogat.technomancy.handlers.handlers;
 
-import net.minecraft.network.NetworkManager;
-
-import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteStreams;
-
 public class PacketHandler /*implements IPacketHandler*/{
 
 //	@Override

--- a/src/main/java/theflogat/technomancy/handlers/handlers/ResearchHandler.java
+++ b/src/main/java/theflogat/technomancy/handlers/handlers/ResearchHandler.java
@@ -20,7 +20,7 @@ import theflogat.technomancy.lib.Ids;
 
 public class ResearchHandler {
 	
-	public static HashMap<String, Object> recipes = new HashMap();
+	public static HashMap<String, Object> recipes = new HashMap<String, Object>();
 	
 	public static void init() {
 		try{

--- a/src/main/java/theflogat/technomancy/handlers/proxies/ClientProxy.java
+++ b/src/main/java/theflogat/technomancy/handlers/proxies/ClientProxy.java
@@ -154,7 +154,8 @@ public class ClientProxy extends CommonProxy implements IGuiHandler{
     }
     
     
-    public void essentiaTrail(World world, double x, double y, double z, double tx, double ty, double tz, int color) {
+    @Override
+	public void essentiaTrail(World world, double x, double y, double z, double tx, double ty, double tz, int color) {
     	if(Minecraft.getMinecraft().renderViewEntity == null) {
     	      return;
     	}

--- a/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
+++ b/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
@@ -11,7 +11,7 @@ public class ItemHelper {
 	
 	
 	public static ItemStack getFirstItemStack(CompareItemStack comp) {
-		Iterator it = Item.itemRegistry.iterator();
+		Iterator<?> it = Item.itemRegistry.iterator();
 		while(it.hasNext()) {
 			Item item = (Item) it.next();
 			if(item.getHasSubtypes()){
@@ -34,7 +34,7 @@ public class ItemHelper {
 			}
 		}
 		
-		Iterator bl = Block.blockRegistry.iterator();
+		Iterator<?> bl = Block.blockRegistry.iterator();
 		while(bl.hasNext()) {
 			ItemStack items = new ItemStack((Block)bl.next());
 			if(comp.isCorrectItemStack(items))

--- a/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
+++ b/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
@@ -12,7 +12,7 @@ public class ItemHelper {
 	
 	public static ItemStack getFirstItemStack(CompareItemStack comp) {
 		Iterator it = Item.itemRegistry.iterator();
-		for(int i=0; it.hasNext(); i++){
+		while(it.hasNext()) {
 			Item item = (Item) it.next();
 			if(item.getHasSubtypes()){
 				ArrayList<ItemStack> l = new ArrayList<ItemStack>();
@@ -35,7 +35,7 @@ public class ItemHelper {
 		}
 		
 		Iterator bl = Block.blockRegistry.iterator();
-		for(int i=0; bl.hasNext(); i++){
+		while(bl.hasNext()) {
 			ItemStack items = new ItemStack((Block)bl.next());
 			if(comp.isCorrectItemStack(items))
 				return items;

--- a/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
+++ b/src/main/java/theflogat/technomancy/handlers/util/ItemHelper.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import net.minecraft.block.Block;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 


### PR DESCRIPTION
Resolves the majority of warnings reported by eclipse.

The majority of these changes are removal of unused imports and adding missing annotations, so do not change actual executing code.

Classes that appeared to still be under development were not changed. 