### PR TITLE
More bug fixes

### DIFF
--- a/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/renderers/tiles/TileEssentiaContainerRenderer.java
@@ -49,9 +49,9 @@ public class TileEssentiaContainerRenderer extends TileEntitySpecialRenderer{
 		        GL11.glPushMatrix();
 		        GL11.glTranslated(0, 1.5, 0);
 		        switch (((TileEssentiaContainer)tile).facing) {
-		        case 3:  GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F); break;
-		        case 5:  GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F); break;
-		        case 4:  GL11.glRotatef(270.0F, 0.0F, 1.0F, 0.0F);
+		        case 2:  GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F); break;
+		        case 4:  GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F); break;
+		        case 5:  GL11.glRotatef(270.0F, 0.0F, 1.0F, 0.0F);
 		        }
 		        
 		        float rot = (((TileEssentiaContainer)tile).aspectFilter.getTag().hashCode() + ((TileEssentiaContainer)tile).xCoord + ((TileEssentiaContainer)tile).facing) % 4 - 2;

--- a/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/storage/BlockEssentiaContainer.java
@@ -99,6 +99,7 @@ public class BlockEssentiaContainer extends BlockBase {
 						}
 						player.inventoryContainer.detectAndSendChanges();
 					}
+					onBlockPlacedBy(world, x, y, z, player, null);
 					return true;
 				}				
 				//Adds Essentia from Phials

--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileNodeDynamo.java
@@ -40,8 +40,7 @@ public class TileNodeDynamo extends TileDynamoBase{
 					Aspect[] as = node.getAspects().getAspects();
 					for (int i = 0; i < as.length; i++) {
 						Aspect aspect = as[i];
-						int nodeAmount = node.containerContains(aspect);
-						if(nodeAmount!= 1 && amount < 16){
+						if(node.getAspects().getAmount(aspect) > 1 && amount < 16){
 							if(node.takeFromContainer(aspect, 1) ) {
 								amount += 1;
 							}

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
@@ -21,7 +21,6 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	int amount = 0;
 	int maxAmount = 32;
-	Aspect aspect;
 	public FluidTank tank = new FluidTank(1000);	
 	Aspect aspectSuction;
 	boolean stabilize = true;
@@ -29,19 +28,15 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public void writeCustomNBT(NBTTagCompound compound) {
-		compound.setInteger("Amount", amount);
+		compound.setInteger("AspectAmount", amount);
 		compound.setBoolean("Stabilize", stabilize);
-		if (aspect != null) {
-			compound.setString("Aspect", aspect.getTag());
-		}	
 		compound.setBoolean("Placed", placed);
 		tank.writeToNBT(compound);
 	}
 
 	@Override
 	public void readCustomNBT(NBTTagCompound compound) {
-		amount = compound.getInteger("Amount");
-		aspect = Aspect.getAspect(compound.getString("Aspect"));
+		amount = compound.getInteger("AspectAmount");
 		stabilize = compound.getBoolean("Stabilize");
 		placed = compound.getBoolean("Placed");
 		tank = new FluidTank(1000);
@@ -54,7 +49,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 		try{
 			if(!worldObj.isRemote) {
 				TileEntity tile = null;
-				if ((!worldObj.isRemote) && (++count % 10 == 0)) {
+				if (!worldObj.isRemote && ++count % 10 == 0) {
 					if(amount < maxAmount) {
 						fill();
 					}
@@ -66,10 +61,10 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 				if(!Thaumcraft.TileInfusionMatrix.getField("crafting").getBoolean(tile)) {
 					this.stabilize = true;
 				}	
-				if((Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) > 0 && stabilize) {
+				if(Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile) > 0 && stabilize) {
 					for(int i = 0; i < 5; i++) {					
 						if(amount >= 5 && (tank.getCapacity() - tank.getFluidAmount()) >= 200 && stabilize) {
-							takeFromContainer(aspect, 5);
+							takeFromContainer(Aspect.ORDER, 5);
 							Thaumcraft.TileInfusionMatrix.getField("instability").set(tile,
 									(Thaumcraft.TileInfusionMatrix.getField("instability").getInt(tile)) - 1);
 							tank.fill(FluidRegistry.getFluidStack(Thaumcraft.FLUXGOO.getName(), 200), true);
@@ -106,15 +101,9 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 			if (!ic.canOutputTo(ForgeDirection.DOWN)) {
 				return;
 			}
-			Aspect ta = null;
-			if ((this.aspect != null) && (this.amount > 0)) {
-				ta = this.aspect;
-			} else if ((ic.getEssentiaAmount(ForgeDirection.DOWN) > 0) && 
-					(ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP)) && (getSuctionAmount(ForgeDirection.UP) >= ic.getMinimumSuction())) {
-				ta = ic.getEssentiaType(ForgeDirection.DOWN);
-			}
-			if ((ta != null) && (ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP))) {
-				addToContainer(ta, ic.takeEssentia(ta, 1, ForgeDirection.DOWN));
+			if (ic.getEssentiaAmount(ForgeDirection.DOWN) > 0 && ic.getEssentiaType(ForgeDirection.DOWN) == Aspect.ORDER &&
+					ic.getSuctionAmount(ForgeDirection.DOWN) < getSuctionAmount(ForgeDirection.UP) && getSuctionAmount(ForgeDirection.UP) >= ic.getMinimumSuction()) {
+				addToContainer(Aspect.ORDER, ic.takeEssentia(Aspect.ORDER, 1, ForgeDirection.DOWN));
 			}
 		}
 	}
@@ -122,19 +111,18 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 	@Override
 	public AspectList getAspects()  {
 		AspectList al = new AspectList();
-		if ((this.aspect != null) && (this.amount > 0)) {
-			al.add(this.aspect, this.amount);
+		if (this.amount > 0) {
+			al.add(Aspect.ORDER, this.amount);
 		}
 		return al;
-	}	  
-
+	}
+	
 	@Override
 	public int addToContainer(Aspect tag, int amount)  {
 		if (amount == 0) {
 			return amount;
 		}
-		if (((this.amount < this.maxAmount) && (tag == this.aspect)) || (this.amount == 0)) {
-			this.aspect = tag;
+		if (this.amount < this.maxAmount && tag == Aspect.ORDER) {
 			int added = Math.min(amount, this.maxAmount - this.amount);
 			this.amount += added;
 			amount -= added;
@@ -145,12 +133,8 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean takeFromContainer(Aspect tag, int amount)  {
-		if ((this.amount >= amount) && (tag == this.aspect)) {
+		if (this.amount >= amount && tag == Aspect.ORDER) {
 			this.amount -= amount;
-			if (this.amount <= 0) {
-				this.aspect = null;
-				this.amount = 0;
-			}
 			this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
 			return true;
 		}
@@ -159,7 +143,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean doesContainerContainAmount(Aspect tag, int amt) {
-		if ((this.amount >= amt) && (tag == this.aspect)) {
+		if (amount >= amt && tag == Aspect.ORDER) {
 			return true;
 		}
 		return false;
@@ -167,10 +151,11 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public boolean doesContainerContain(AspectList ot)  {
-		for (Aspect tt : ot.getAspects()) {
-			if ((this.amount > 0) && (tt == this.aspect)) {
-				return true;
-			}
+		if (ot.size() > 1) {
+			return false;
+		}
+		if (ot.getAspects()[1] == Aspect.ORDER && this.amount >= ot.getAmount(Aspect.ORDER)) {
+			return true;
 		}
 		return false;
 	}
@@ -231,9 +216,9 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 	@Override
 	public Aspect getSuctionType(ForgeDirection face) {
 		if(this.amount < this.maxAmount) {
-			this.aspectSuction = Aspect.ORDER;
+			return Aspect.ORDER;
 		}
-		return this.aspectSuction;
+		return null;
 	}
 
 	@Override
@@ -251,7 +236,7 @@ public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, I
 
 	@Override
 	public Aspect getEssentiaType(ForgeDirection face) {
-		return this.aspect;
+		return amount > 0 ? Aspect.ORDER : null;
 	}
 
 	@Override


### PR DESCRIPTION
These commits fix a few issues:
- Fixes Flux Lamp not properly keeping track of Flux Goo and Essentia due to  the NBT tag "amount" being used for both
- Fixes issue where Node Dynamo would drain a node dry and damage it because the method it used to read the Vis amount of the node always returned invalid data
- Fixes the placement, orientation, and removal of labels on Quantum Jars. They were being placed on the opposite side of the jar from whatever direction the player was facing when the jar was placed.