### PR TITLE
Update Mana fabricator to have a default cost of 1,000,000 RF similarly ...

### DIFF
--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileFlowerDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileFlowerDynamo.java
@@ -21,7 +21,7 @@ public class TileFlowerDynamo extends TileDynamoBase implements IManaReceiver {
 		float ratio = (ener) / 80F;
 		int val = (int) (20 * ratio);
 		float fuel = (float) val / (float) Math.min(mana, val);mana -= Math.min(mana, val);
-		return (int) (((float)10*20)*fuel);
+		return (int) (((float)10*16)*fuel);
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/lib/Rate.java
+++ b/src/main/java/theflogat/technomancy/lib/Rate.java
@@ -17,7 +17,7 @@ public final class Rate {
        	bellowsCost = config.get(category, "ElectricBellows", bellowsCost).getInt(Rate.bellowsCost);
 	}
 	
-	public static int manaFabCost = 20000;
+	public static int manaFabCost = 1000000;
 	public static int bloodFabCost = 1000000;
 	public static int condenserCost = 1000000;
 	public static int biomeMorpherCost = 20000;


### PR DESCRIPTION
...to the other fabricators.

This fixes issue #63

This will not resolve the issue with existing installs unless the config file is regenerated, but will prevent the exploit on any new installs.

Prior to this change the ratio of energy consumed by the Mana Fabricator vs. the energy produced by the Hippie Dynamo for that Mana was 1 to 4, after this set of commits it is 15.6 to 1. This is more in line with the ratio of the Essentia Dynamo.