### PR TITLE
Improve Blood Dynamo fuel values

### DIFF
--- a/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/dynamos/TileBloodDynamo.java
@@ -21,7 +21,7 @@ public class TileBloodDynamo extends TileDynamoBase implements IFluidHandler {
 			float val = 100F * ratio;
 			float fuelPerc = val / Math.min(liquid, val);
 			liquid -= Math.min(liquid, val);
-			float fuel = 12F * fuelPerc;
+			float fuel = 400F * fuelPerc;
 			return (int) fuel;
 		}
 		return 0;


### PR DESCRIPTION
The Blood Dynamo under-produces power per fuel compared to the other dynamos.

This commit increases the fuel produced per milibucket of blood to be on par with the other Dynamos. This brings the ratio of Blood produced by a Blood fabricator to the amount of Blood consumed to produce that power to 15.6 to 1, which is in line with the Essentia Dynamo.