### PR TITLE
Fixes several issues:

### DIFF
--- a/src/main/java/theflogat/technomancy/client/models/ModelTeslaCoil.java
+++ b/src/main/java/theflogat/technomancy/client/models/ModelTeslaCoil.java
@@ -5,115 +5,119 @@ import net.minecraft.client.model.ModelRenderer;
 
 public class ModelTeslaCoil extends ModelBase
 {
-  //fields
-    ModelRenderer Base;
-    ModelRenderer Post;
-    ModelRenderer Core;
-    ModelRenderer TopCore;
-    ModelRenderer RightCore;
-    ModelRenderer LeftCore;
-    ModelRenderer BackCore;
-    ModelRenderer FrontCore;
-    ModelRenderer BottomCore;
-    ModelRenderer TopRing;
-    ModelRenderer BottomRing;
-  
-  public ModelTeslaCoil()
-  {
-    textureWidth = 64;
-    textureHeight = 32;
-    
-      Base = new ModelRenderer(this, 0, 25);
-      Base.addBox(-3F, 0F, -3F, 6, 1, 6);
-      Base.setRotationPoint(0F, 23F, 0F);
-      Base.setTextureSize(64, 32);
-      Base.mirror = true;
-      setRotation(Base, 0F, 0F, 0F);
-      Post = new ModelRenderer(this, 12, 2);
-      Post.addBox(-0.5F, 0F, -0.5F, 1, 10, 1);
-      Post.setRotationPoint(0F, 13F, 0F);
-      Post.setTextureSize(64, 32);
-      Post.mirror = true;
-      setRotation(Post, 0F, 0F, 0F);
-      Core = new ModelRenderer(this, 0, 7);
-      Core.addBox(-1.5F, -1.5F, -1.5F, 3, 3, 3);
-      Core.setRotationPoint(0F, 12F, 0F);
-      Core.setTextureSize(64, 32);
-      Core.mirror = true;
-      setRotation(Core, 0F, 0F, 0F);
-      TopCore = new ModelRenderer(this, 0, 0);
-      TopCore.addBox(-1F, -1F, -1F, 2, 1, 2);
-      TopCore.setRotationPoint(0F, 11F, 0F);
-      TopCore.setTextureSize(64, 32);
-      TopCore.mirror = true;
-      setRotation(TopCore, 0F, 0F, 0F);
-      RightCore = new ModelRenderer(this, 0, 0);
-      RightCore.addBox(-1F, 0F, -1F, 2, 2, 2);
-      RightCore.setRotationPoint(1F, 11F, 0F);
-      RightCore.setTextureSize(64, 32);
-      RightCore.mirror = true;
-      setRotation(RightCore, 0F, 0F, 0F);
-      LeftCore = new ModelRenderer(this, 0, 0);
-      LeftCore.addBox(-1F, 0F, -1F, 2, 2, 2);
-      LeftCore.setRotationPoint(-1F, 11F, 0F);
-      LeftCore.setTextureSize(64, 32);
-      LeftCore.mirror = true;
-      setRotation(LeftCore, 0F, 0F, 0F);
-      BackCore = new ModelRenderer(this, 0, 0);
-      BackCore.addBox(-1F, 0F, -1F, 2, 2, 2);
-      BackCore.setRotationPoint(0F, 11F, 1F);
-      BackCore.setTextureSize(64, 32);
-      BackCore.mirror = true;
-      setRotation(BackCore, 0F, 0F, 0F);
-      FrontCore = new ModelRenderer(this, 0, 0);
-      FrontCore.addBox(-1F, 0F, -1F, 2, 2, 2);
-      FrontCore.setRotationPoint(0F, 12F, -2F);
-      FrontCore.setTextureSize(64, 32);
-      FrontCore.mirror = true;
-      setRotation(FrontCore, 1.570796F, 0F, 0F);
-      BottomCore = new ModelRenderer(this, 0, 0);
-      BottomCore.addBox(-1F, 0F, -1F, 2, 1, 2);
-      BottomCore.setRotationPoint(0F, 13F, 0F);
-      BottomCore.setTextureSize(64, 32);
-      BottomCore.mirror = true;
-      setRotation(BottomCore, 0F, 0F, 0F);
-      TopRing = new ModelRenderer(this, 0, 13);
-      TopRing.addBox(-2F, 0F, -2F, 4, 1, 4);
-      TopRing.setRotationPoint(0F, 16F, 0F);
-      TopRing.setTextureSize(64, 32);
-      TopRing.mirror = true;
-      setRotation(TopRing, 0F, 0F, 0F);
-      BottomRing = new ModelRenderer(this, 0, 18);
-      BottomRing.addBox(-3F, 0F, -3F, 6, 1, 6);
-      BottomRing.setRotationPoint(0F, 19F, 0F);
-      BottomRing.setTextureSize(64, 32);
-      BottomRing.mirror = true;
-      setRotation(BottomRing, 0F, 0F, 0F);
-  }
-  
- public void render()  {
-	    final float f5 = 1.0F/16.0F;
-	    Base.render(f5);
-	    Post.render(f5);
-	    Core.render(f5);
-	    TopCore.render(f5);
-	    RightCore.render(f5);
-	    LeftCore.render(f5);
-	    BackCore.render(f5);
-	    FrontCore.render(f5);
-	    BottomCore.render(f5);
- }
- public void renderRings() {
-	 final float f5 = 1.0F/16.0F;
+	//fields
+	ModelRenderer Base;
+	ModelRenderer Post;
+	ModelRenderer Core;
+	ModelRenderer TopCore;
+	ModelRenderer RightCore;
+	ModelRenderer LeftCore;
+	ModelRenderer BackCore;
+	ModelRenderer FrontCore;
+	ModelRenderer BottomCore;
+	ModelRenderer TopRing;
+	ModelRenderer BottomRing;
 
-	    TopRing.render(f5);
+	public ModelTeslaCoil()
+	{
+		textureWidth = 64;
+		textureHeight = 32;
+
+		Base = new ModelRenderer(this, 0, 25);
+		Base.addBox(-3F, 0F, -3F, 6, 1, 6);
+		Base.setRotationPoint(0F, 23F, 0F);
+		Base.setTextureSize(64, 32);
+		Base.mirror = true;
+		setRotation(Base, 0F, 0F, 0F);
+		Post = new ModelRenderer(this, 12, 2);
+		Post.addBox(-0.5F, 0F, -0.5F, 1, 10, 1);
+		Post.setRotationPoint(0F, 13F, 0F);
+		Post.setTextureSize(64, 32);
+		Post.mirror = true;
+		setRotation(Post, 0F, 0F, 0F);
+		Core = new ModelRenderer(this, 0, 7);
+		Core.addBox(-1.5F, -1.5F, -1.5F, 3, 3, 3);
+		Core.setRotationPoint(0F, 12F, 0F);
+		Core.setTextureSize(64, 32);
+		Core.mirror = true;
+		setRotation(Core, 0F, 0F, 0F);
+		TopCore = new ModelRenderer(this, 0, 0);
+		TopCore.addBox(-1F, -1F, -1F, 2, 1, 2);
+		TopCore.setRotationPoint(0F, 11F, 0F);
+		TopCore.setTextureSize(64, 32);
+		TopCore.mirror = true;
+		setRotation(TopCore, 0F, 0F, 0F);
+		RightCore = new ModelRenderer(this, 0, 0);
+		RightCore.addBox(-1F, 0F, -1F, 2, 2, 2);
+		RightCore.setRotationPoint(1F, 11F, 0F);
+		RightCore.setTextureSize(64, 32);
+		RightCore.mirror = true;
+		setRotation(RightCore, 0F, 0F, 0F);
+		LeftCore = new ModelRenderer(this, 0, 0);
+		LeftCore.addBox(-1F, 0F, -1F, 2, 2, 2);
+		LeftCore.setRotationPoint(-1F, 11F, 0F);
+		LeftCore.setTextureSize(64, 32);
+		LeftCore.mirror = true;
+		setRotation(LeftCore, 0F, 0F, 0F);
+		BackCore = new ModelRenderer(this, 0, 0);
+		BackCore.addBox(-1F, 0F, -1F, 2, 2, 2);
+		BackCore.setRotationPoint(0F, 11F, 1F);
+		BackCore.setTextureSize(64, 32);
+		BackCore.mirror = true;
+		setRotation(BackCore, 0F, 0F, 0F);
+		FrontCore = new ModelRenderer(this, 0, 0);
+		FrontCore.addBox(-1F, 0F, -1F, 2, 2, 2);
+		FrontCore.setRotationPoint(0F, 12F, -2F);
+		FrontCore.setTextureSize(64, 32);
+		FrontCore.mirror = true;
+		setRotation(FrontCore, 1.570796F, 0F, 0F);
+		BottomCore = new ModelRenderer(this, 0, 0);
+		BottomCore.addBox(-1F, 0F, -1F, 2, 1, 2);
+		BottomCore.setRotationPoint(0F, 13F, 0F);
+		BottomCore.setTextureSize(64, 32);
+		BottomCore.mirror = true;
+		setRotation(BottomCore, 0F, 0F, 0F);
+		TopRing = new ModelRenderer(this, 0, 13);
+		TopRing.addBox(-2F, 0F, -2F, 4, 1, 4);
+		TopRing.setRotationPoint(0F, 16F, 0F);
+		TopRing.setTextureSize(64, 32);
+		TopRing.mirror = true;
+		setRotation(TopRing, 0F, 0F, 0F);
+		BottomRing = new ModelRenderer(this, 0, 18);
+		BottomRing.addBox(-3F, 0F, -3F, 6, 1, 6);
+		BottomRing.setRotationPoint(0F, 19F, 0F);
+		BottomRing.setTextureSize(64, 32);
+		BottomRing.mirror = true;
+		setRotation(BottomRing, 0F, 0F, 0F);
+	}
+
+	public void render()  {
+		final float f5 = 1.0F/16.0F;
+		Base.render(f5);
+		Post.render(f5);
+		Core.render(f5);
+		TopCore.render(f5);
+		RightCore.render(f5);
+		LeftCore.render(f5);
+		BackCore.render(f5);
+		FrontCore.render(f5);
+		BottomCore.render(f5);
+	}
+
+	public void renderTopRing() {
+		final float f5 = 1.0F/16.0F;
+		TopRing.render(f5);
+	}
+
+	public void renderBottomRing() {
+		final float f5 = 1.0F/16.0F;
 		BottomRing.render(f5);
- }
- 
-private static void setRotation(ModelRenderer model, float x, float y, float z) {
-	    model.rotateAngleX = x;
-	    model.rotateAngleY = y;
-	    model.rotateAngleZ = z;
-	  }
+	}
+
+	private static void setRotation(ModelRenderer model, float x, float y, float z) {
+		model.rotateAngleX = x;
+		model.rotateAngleY = y;
+		model.rotateAngleZ = z;
+	}
 
 }

--- a/src/main/java/theflogat/technomancy/client/tiles/TileEssentiaTransmitterRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/tiles/TileEssentiaTransmitterRenderer.java
@@ -1,10 +1,13 @@
 package theflogat.technomancy.client.tiles;
 
 import java.awt.Color;
+
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.opengl.GL11;
+
 import theflogat.technomancy.client.models.ModelTeslaCoil;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileEssentiaTransmitter;
 import theflogat.technomancy.lib.Ref;
@@ -32,11 +35,20 @@ public class TileEssentiaTransmitterRenderer extends TileEntitySpecialRenderer {
 		model.render();
 		
 		GL11.glPushMatrix();
+		if(((TileEssentiaTransmitter)entity).boost) {
+			GL11.glColor3d(Color.RED.getRed(), 0, 0);
+		}
+		model.renderTopRing();
+		GL11.glColor3d(1, 1, 1);
+		GL11.glPopMatrix();
+		
+		GL11.glPushMatrix();
 		if(((TileEssentiaTransmitter)entity).aspectFilter != null) {
 			Color color = new Color(((TileEssentiaTransmitter)entity).aspectFilter.getColor());
 			GL11.glColor3d(color.getRed() / 255.0F * 0.2F, color.getGreen() / 255.0F * 0.2F, color.getBlue() / 255.0F * 0.2F);
 		}
-		model.renderRings();
+		model.renderBottomRing();
+		GL11.glColor3d(1, 1, 1);
 		GL11.glPopMatrix();
 		
 		GL11.glPopMatrix();

--- a/src/main/java/theflogat/technomancy/client/tiles/TileItemTransmitterRenderer.java
+++ b/src/main/java/theflogat/technomancy/client/tiles/TileItemTransmitterRenderer.java
@@ -37,10 +37,17 @@ public class TileItemTransmitterRenderer  extends TileEntitySpecialRenderer {
 		GL11.glPushMatrix();
 		if(((TileItemTransmitter)entity).boost) {
 			GL11.glColor3d(Color.RED.getRed(), 0, 0);
-			if(((TileItemTransmitter)entity).filter!=null)
-				GL11.glColor3d(0, Color.GREEN.getGreen(), 0);
 		}
-		model.renderRings();
+		model.renderTopRing();
+		GL11.glColor3d(1, 1, 1);
+		GL11.glPopMatrix();
+		
+		GL11.glPushMatrix();
+		if(((TileItemTransmitter)entity).filter != null) {
+			GL11.glColor3d(0, Color.GREEN.getGreen(), 0);
+		}
+		model.renderBottomRing();
+		GL11.glColor3d(1, 1, 1);
 		GL11.glPopMatrix();
 		
 		GL11.glPopMatrix();

--- a/src/main/java/theflogat/technomancy/common/blocks/air/BlockFakeAirNG.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/air/BlockFakeAirNG.java
@@ -71,7 +71,7 @@ public class BlockFakeAirNG extends BlockContainer{
 				return true;
 			}
 		}
-		if(items!=null && itemToSetting.containsKey(items.getItem())) {
+		if(items!=null && itemToSetting.containsKey(items.getItem()) && fakeAir.canBeModified()) {
 			if(itemToSetting.get(items.getItem())!=fakeAir.getCurrentSetting()){
 				if(fakeAir.isModified()) {
 					Item it = settingToItem.get(fakeAir.getCurrentSetting());

--- a/src/main/java/theflogat/technomancy/common/blocks/base/BlockContainerAdvanced.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/base/BlockContainerAdvanced.java
@@ -86,7 +86,7 @@ public abstract class BlockContainerAdvanced extends BlockContainerRedstone{
 	public void getNBTInfo(NBTTagCompound comp, ArrayList<String> l, int meta){
 		dummy.readFromNBT(comp);
 		if(dummy instanceof IEnergyHandler){
-			l.add("Energy:" + ((IEnergyHandler)dummy).getEnergyStored(null) + "/" + ((IEnergyHandler)dummy).getMaxEnergyStored(null));
+			l.add("Energy: " + ((IEnergyHandler)dummy).getEnergyStored(null) + "/" + ((IEnergyHandler)dummy).getMaxEnergyStored(null));
 		}
 		if(CompatibilityHandler.th && dummy instanceof thaumcraft.api.aspects.IAspectContainer){
 			if(Keyboard.isKeyDown(Keyboard.KEY_A)){
@@ -107,7 +107,7 @@ public abstract class BlockContainerAdvanced extends BlockContainerRedstone{
 		}
 		if(dummy instanceof IRedstoneSensitive){
 			RedstoneSet set = RedstoneSet.load(comp);
-			l.add("Redstone Setting:" + set.toString());
+			l.add("Redstone Setting: " + set.toString());
 		}
 		if(dummy instanceof IInventory){
 			if(Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL)){
@@ -126,8 +126,11 @@ public abstract class BlockContainerAdvanced extends BlockContainerRedstone{
 		}
 		if(dummy instanceof IFluidHandler){
 			FluidTankInfo[] infoTanks = ((IFluidHandler)dummy).getTankInfo(null);
-			for(FluidTankInfo info:infoTanks)
-				l.add(info.fluid.getLocalizedName() + ":" + info.fluid.amount + "/" + info.capacity);
+			for(FluidTankInfo info:infoTanks) {
+				if(info.fluid != null) {
+					l.add(info.fluid.getLocalizedName() + ": " + info.fluid.amount + "/" + info.capacity);
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/theflogat/technomancy/common/blocks/base/BlockContainerRedstone.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/base/BlockContainerRedstone.java
@@ -34,7 +34,7 @@ public abstract class BlockContainerRedstone extends BlockContainerBase {
 		IRedstoneSensitive te = getTE(w, x, y, z);
 		if(te != null) {
 			ItemStack items = player.inventory.mainInventory[player.inventory.currentItem];
-			if(items!=null && itemToSetting.containsKey(items.getItem())) {
+			if(items!=null && itemToSetting.containsKey(items.getItem()) && te.canBeModified()) {
 				if(itemToSetting.get(items.getItem())!=te.getCurrentSetting()){
 					if(te.isModified()) {
 						Item it = settingToItem.get(te.getCurrentSetting());

--- a/src/main/java/theflogat/technomancy/common/blocks/bloodmagic/machines/BlockBloodFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/bloodmagic/machines/BlockBloodFabricator.java
@@ -1,12 +1,10 @@
 package theflogat.technomancy.common.blocks.bloodmagic.machines;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 import theflogat.technomancy.common.blocks.base.BlockContainerAdvanced;
@@ -51,13 +49,6 @@ public class BlockBloodFabricator extends BlockContainerAdvanced {
 		}
 		return super.onBlockActivated(w, x, y, z, player, side, hitX, hitY, hitZ);
 	}
-	
-	@Override
-	public void onBlockPlacedBy(World w, int x, int y, int z, EntityLivingBase entity, ItemStack items)    {
-		super.onBlockPlacedBy(w, x, y, z, entity, items);
-        int rotation = MathHelper.floor_double(entity.rotationYaw * 4.0F / 360.0F + 2.5D) & 3;
-        w.setBlockMetadataWithNotify(x, y, z, rotation, 2);
-    }
 	
 	@SideOnly(Side.CLIENT)
 	@Override

--- a/src/main/java/theflogat/technomancy/common/blocks/botania/machines/BlockManaFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/botania/machines/BlockManaFabricator.java
@@ -29,20 +29,19 @@ public class BlockManaFabricator extends BlockContainerAdvanced implements IWand
 		return new TileManaFabricator();
 	}
 	
-	private int facing;	
 	@Override
 	public void onBlockPlacedBy(World w, int x, int y, int z, EntityLivingBase entity, ItemStack items){
 		super.onBlockPlacedBy(w, x, y, z, entity, items);
 		TileEntity tile = w.getTileEntity(x, y, z);
 		if(tile instanceof TileManaFabricator) {
-			((TileManaFabricator)tile).facing = this.facing;
+			((TileManaFabricator)tile).facing = w.getBlockMetadata(x, y, z);
+			w.setBlockMetadataWithNotify(x, y, z, 0, 0);
 		}
 	}
 	
 	@Override
 	public int onBlockPlaced(World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int meta){
-		this.facing = ForgeDirection.OPPOSITES[side];
-		return side + meta;
+		return ForgeDirection.OPPOSITES[side];
 	}
 	
 	@Override

--- a/src/main/java/theflogat/technomancy/common/blocks/technom/BlockItemTransmitter.java
+++ b/src/main/java/theflogat/technomancy/common/blocks/technom/BlockItemTransmitter.java
@@ -36,15 +36,15 @@ public class BlockItemTransmitter extends BlockCoilTransmitter{
 		}
 		TileItemTransmitter tile = getTE(w, x, y, z);
 		if(tile!= null){
-			if(player.isSneaking()){
-				if(tile.filter!=null){
+			if(player.isSneaking()) {
+				if(tile.filter!=null) {
 					if(!w.isRemote) {
 						tile.filter = null;
 						w.markBlockForUpdate(x, y, z);
 					}
 					return true;
 				}
-			}else if(items!=null && tile.filter==null){
+			} else if(items!=null && tile.filter==null) {
 				if(!w.isRemote) {
 					tile.addFilter(player.inventory.mainInventory[player.inventory.currentItem]);
 					w.markBlockForUpdate(x, y, z);

--- a/src/main/java/theflogat/technomancy/common/items/base/ItemAdvancedBase.java
+++ b/src/main/java/theflogat/technomancy/common/items/base/ItemAdvancedBase.java
@@ -32,7 +32,7 @@ public class ItemAdvancedBase extends ItemBlock{
 		if(tileInterfaces.contains("IUpgradable")){
 			IUpgradable up = (IUpgradable)((BlockContainerAdvanced)field_150939_a).createNewTileEntity(null, 0);
 			String name = String.format(StatCollector.translateToLocal(field_150939_a.getUnlocalizedName() + ".name"));
-			ItemBoost.upgradeable.add(name + ":" + up.getInfo());
+			ItemBoost.upgradeable.add(name + ": " + up.getInfo());
 		}
 	}
 

--- a/src/main/java/theflogat/technomancy/common/items/technom/ItemCrystal.java
+++ b/src/main/java/theflogat/technomancy/common/items/technom/ItemCrystal.java
@@ -18,10 +18,10 @@ public class ItemCrystal extends ItemBlock{
 	public void addInformation(ItemStack items, EntityPlayer player, List l, boolean moreInfo) {
 		switch(items.getItemDamage()){
 		case 0:
-			l.add("Used for light rituals. Safe for decoration.");
+			l.add("Used for dark rituals. Safe for decoration.");
 			break;
 		case 1:
-			l.add("Used for dark rituals. Safe for decoration.");
+			l.add("Used for light rituals. Safe for decoration.");
 			break;
 		case 2:
 			l.add("Used for fire rituals. Safe for decoration.");

--- a/src/main/java/theflogat/technomancy/common/items/thaumcraft/ItemWandCores.java
+++ b/src/main/java/theflogat/technomancy/common/items/thaumcraft/ItemWandCores.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagByte;
 import net.minecraft.util.IIcon;
+import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.items.wands.ItemWandCasting;
@@ -55,13 +56,23 @@ public class ItemWandCores extends ItemBase{
 		ItemStack electric = new ItemStack(Thaumcraft.itemWandCasting, 1, 72);
 		((ItemWandCasting)electric.getItem()).setCap(electric, WandCap.caps.get("thaumium"));
 		((ItemWandCasting)electric.getItem()).setRod(electric, WandRod.rods.get("electric"));
+		ItemStack electricCharged = electric.copy();
+		for(Aspect al : Aspect.getPrimalAspects()) {
+			((ItemWandCasting)electricCharged.getItem()).addVis(electricCharged, al, 25, true);
+		}
 		list.add(electric);
+		list.add(electricCharged);
 		if(Ids.scepter) {
 			ItemStack scepter = new ItemStack(TMItems.itemTechnoturgeScepter, 1);
 			scepter.setTagInfo("sceptre", new NBTTagByte((byte)1));
 			((ItemWandCasting)scepter.getItem()).setCap(scepter, WandCap.caps.get("thaumium"));
 			((ItemWandCasting)scepter.getItem()).setRod(scepter, WandRod.rods.get("technoturge"));
+			ItemStack scepterCharged = scepter.copy();
+			for(Aspect al : Aspect.getPrimalAspects()) {
+				((ItemWandCasting)scepterCharged.getItem()).addVis(scepterCharged, al, 150, true);
+			}
 			list.add(scepter);
+			list.add(scepterCharged);
 		}
 	}
 	

--- a/src/main/java/theflogat/technomancy/common/tiles/air/TileFakeAirNG.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/air/TileFakeAirNG.java
@@ -291,6 +291,12 @@ public class TileFakeAirNG extends TileFakeAirCore implements IEnergyHandler, IE
 	}
 	
 	@Override
+	public boolean canBeModified() {
+		TileNodeGenerator te = getTE();
+		return te != null ? te.canBeModified() : false;
+	}
+	
+	@Override
 	public boolean onWrenched(boolean sneaking) {
 		TileNodeGenerator te = getTE();
 		return te != null ? te.onWrenched(sneaking) : false;

--- a/src/main/java/theflogat/technomancy/common/tiles/base/IRedstoneSensitive.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/IRedstoneSensitive.java
@@ -78,4 +78,5 @@ public interface IRedstoneSensitive {
 	public RedstoneSet getCurrentSetting();
 	public void setNewSetting(RedstoneSet newSet);
 	public boolean isModified();
+	public boolean canBeModified();
 }

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileCoilTransmitter.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileCoilTransmitter.java
@@ -1,6 +1,11 @@
 package theflogat.technomancy.common.tiles.base;
 
 import java.util.ArrayList;
+
+import theflogat.technomancy.common.blocks.base.BlockContainerRedstone;
+import theflogat.technomancy.util.helpers.WorldHelper;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChunkCoordinates;
 
@@ -62,6 +67,7 @@ public abstract class TileCoilTransmitter extends TileTechnomancyRedstone implem
 	@Override
 	public boolean toggleBoost() {
 		boost = !boost;
+		fixRedstone();
 		return boost;
 	}
 
@@ -73,6 +79,28 @@ public abstract class TileCoilTransmitter extends TileTechnomancyRedstone implem
 	@Override
 	public void setBoost(boolean newBoost) {
 		boost = newBoost;
+		fixRedstone();
+	}
+	
+	@Override
+	public boolean canBeModified() {
+		return !boost;
+	}
+
+	private void fixRedstone() {
+		if(boost) {
+			if(modified) {
+				Item it = BlockContainerRedstone.settingToItem.get(set);
+				if(!worldObj.isRemote) {
+					WorldHelper.spawnEntItem(worldObj, xCoord, yCoord, zCoord, new ItemStack(it, 1));
+				}
+				modified = false;
+			}
+			set = RedstoneSet.NONE;
+		} else {
+			set = RedstoneSet.LOW;
+		}
+		
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileDynamoBase.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileDynamoBase.java
@@ -38,9 +38,7 @@ public abstract class TileDynamoBase extends TileTechnomancyRedstone implements 
 			}
 		}
 		
-		if(ener>0){
-			updateAdjacentHandlers();
-		}
+		updateAdjacentHandlers();
 	}
 
 	public int calcEner() {
@@ -49,14 +47,15 @@ public abstract class TileDynamoBase extends TileTechnomancyRedstone implements 
 
 	public void update() {
 		worldObj.updateLightByType(EnumSkyBlock.Block, xCoord, yCoord, zCoord);
-		shouldRefresh(worldObj.getBlock(xCoord, yCoord, zCoord), worldObj.getBlock(xCoord, yCoord, zCoord), 0, 0, worldObj, xCoord, yCoord, zCoord);
 		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
 	protected void updateAdjacentHandlers() {
-		TileEntity tile = WorldHelper.getAdjacentTileEntity(this, facing);
-		if(WorldHelper.isEnergyHandlerFromOppFacing(tile, facing)) {
-			ener -= ((IEnergyHandler)tile).receiveEnergy(ForgeDirection.VALID_DIRECTIONS[facing].getOpposite(), Math.min(maxExtract, ener), false);		
+		if(ener>0){
+			TileEntity tile = WorldHelper.getAdjacentTileEntity(this, facing);
+			if(WorldHelper.isEnergyHandlerFromOppFacing(tile, facing)) {
+				ener -= ((IEnergyHandler)tile).receiveEnergy(ForgeDirection.VALID_DIRECTIONS[facing].getOpposite(), Math.min(maxExtract, ener), false);		
+			}
 		}
 		update();
 	}
@@ -162,20 +161,14 @@ public abstract class TileDynamoBase extends TileTechnomancyRedstone implements 
 	
 	@Override
 	public boolean onWrenched(boolean sneaking) {
-		for (int i = facing + 1; i < facing + 6; i++){
-			TileEntity tile = WorldHelper.getAdjacentTileEntity(this, (byte) (i % 6));
-			if ((tile instanceof IEnergyHandler)) {
-				facing = (byte) (i % 6);
-				worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-				updateAdjacentHandlers();
-				return true;
-			}
-		}
 		for (int i = facing + 1; i < facing + 6; i++) {
-			if (WorldHelper.isEnergyHandlerFromOppFacing(this, (byte) (i % 6))) {
-				facing = (byte) (i % 6);
-				worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-				updateAdjacentHandlers();
+			TileEntity tile = WorldHelper.getAdjacentTileEntity(this, (byte) (i % 6));
+			if (WorldHelper.isEnergyHandlerFromOppFacing(tile, (byte) (i % 6))) {
+				if(!worldObj.isRemote) {
+					facing = (byte) (i % 6);
+					worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
+					updateAdjacentHandlers();
+				}
 				return true;
 			}
 		}

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileMachineRedstone.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileMachineRedstone.java
@@ -27,6 +27,11 @@ public abstract class TileMachineRedstone extends TileMachineBase implements IRe
 	public boolean isModified() {
 		return modified;
 	}
+	
+	@Override
+	public boolean canBeModified() {
+		return true;
+	}
 
 	@Override
 	public void readCustomNBT(NBTTagCompound comp) {

--- a/src/main/java/theflogat/technomancy/common/tiles/base/TileTechnomancyRedstone.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/base/TileTechnomancyRedstone.java
@@ -5,7 +5,7 @@ import net.minecraft.nbt.NBTTagCompound;
 public abstract class TileTechnomancyRedstone extends TileTechnomancy implements IRedstoneSensitive {
 
 	public RedstoneSet set = RedstoneSet.HIGH;
-	private boolean modified = false;
+	protected boolean modified = false;
 
 	public TileTechnomancyRedstone(RedstoneSet setDefault) {
 		super();
@@ -26,6 +26,11 @@ public abstract class TileTechnomancyRedstone extends TileTechnomancy implements
 	@Override
 	public boolean isModified() {
 		return modified;
+	}
+	
+	@Override
+	public boolean canBeModified() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/common/tiles/botania/machines/TileManaFabricator.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/botania/machines/TileManaFabricator.java
@@ -3,14 +3,17 @@ package theflogat.technomancy.common.tiles.botania.machines;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import theflogat.technomancy.common.blocks.base.TMBlocks;
+import theflogat.technomancy.common.tiles.base.IWrenchable;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
 import theflogat.technomancy.lib.handlers.Rate;
+import theflogat.technomancy.util.helpers.WorldHelper;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.mana.IManaPool;
 
-public class TileManaFabricator extends TileMachineBase implements IManaPool {
+public class TileManaFabricator extends TileMachineBase implements IManaPool, IWrenchable {
 	
 	public int maxMana = 100000;
 	public int mana;
@@ -20,6 +23,7 @@ public class TileManaFabricator extends TileMachineBase implements IManaPool {
 	public TileManaFabricator() {
 		super(Rate.manaFabCost * 2);
 	}
+	
 	@Override
 	public void updateEntity() {
 		if(getEnergyStored()>=cost && mana+100<=maxMana) {
@@ -74,6 +78,22 @@ public class TileManaFabricator extends TileMachineBase implements IManaPool {
 	@Override
 	public boolean canConnectEnergy(ForgeDirection from) {
 		return from.ordinal() == facing;
+	}
+
+	@Override
+	public boolean onWrenched(boolean sneaking) {
+		for (int i = facing + 1; i < facing + 6; i++) {
+			TileEntity tile = WorldHelper.getAdjacentTileEntity(this, (byte) (i % 6));
+			if (WorldHelper.isEnergyHandlerFromOppFacing(tile, (byte) (i % 6))) {
+				if(!worldObj.isRemote) {
+					facing = (byte) (i % 6);
+					worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
+					worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+				}
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/src/main/java/theflogat/technomancy/common/tiles/technom/TileItemTransmitter.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/technom/TileItemTransmitter.java
@@ -83,6 +83,8 @@ public class TileItemTransmitter extends TileCoilTransmitter implements IUpgrada
 			NBTTagCompound item = comp.getCompoundTag("filter");
 			filter = ItemStack.loadItemStackFromNBT(item);
 			filter.readFromNBT(item);
+		} else {
+			filter = null;
 		}
 		super.readCustomNBT(comp);
 	}

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileElectricBellows.java
@@ -1,5 +1,7 @@
 package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
+import java.lang.reflect.Field;
+
 import net.minecraft.block.BlockFurnace;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -11,6 +13,7 @@ import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 import thaumcraft.common.tiles.TileAlchemyFurnace;
 import thaumcraft.common.tiles.TileArcaneFurnace;
 import theflogat.technomancy.common.tiles.base.TileMachineBase;
+import theflogat.technomancy.lib.Conf;
 import theflogat.technomancy.lib.handlers.Rate;
 
 public class TileElectricBellows extends TileMachineBase {
@@ -73,6 +76,13 @@ public class TileElectricBellows extends TileMachineBase {
 					}
 					if(((TileAlchemyFurnace)furnace).furnaceBurnTime <= 2 && ((TileAlchemyFurnace)furnace).aspects.visSize() + al.visSize() < 50) {
 						((TileAlchemyFurnace)furnace).furnaceBurnTime = 80;
+						try {
+							Field speedBoost = TileAlchemyFurnace.class.getDeclaredField("speedBoost");
+							speedBoost.setAccessible(true);
+							speedBoost.setBoolean(furnace, true);
+						} catch (Exception e) {
+							Conf.ex(e);
+						}
 						extractEnergy(baseCost * 6, false);
 					}					
 				}

--- a/src/main/java/theflogat/technomancy/lib/compat/Botania.java
+++ b/src/main/java/theflogat/technomancy/lib/compat/Botania.java
@@ -1,12 +1,14 @@
 package theflogat.technomancy.lib.compat;
 
 import java.util.Random;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
+import theflogat.technomancy.Technomancy;
 import theflogat.technomancy.common.blocks.base.TMBlocks;
 import theflogat.technomancy.common.blocks.botania.BlockManaFluid;
 import theflogat.technomancy.common.blocks.botania.dynamos.BlockFlowerDynamo;
@@ -91,7 +93,9 @@ public class Botania extends ModuleBase {
 	}
 
 	@Override
-	public void Init() {}
+	public void Init() {
+		Technomancy.logger.info("Botania compatibility module loaded.");
+	}
 
 	@Override
 	public void PostInit() {
@@ -107,6 +111,8 @@ public class Botania extends ModuleBase {
     	//Registration
     	registerItem(TMItems.itemBO, Names.itemBO);
     	registerItem(TMItems.manaBucket, Names.manaBucket);
+    	
+    	registerBucket(TMBlocks.manaFluid, TMBlocks.manaFluidBlock, TMItems.manaBucket);
 	}
 
 	@Override
@@ -128,8 +134,6 @@ public class Botania extends ModuleBase {
 		registerTileEntity(TMBlocks.manaFabricator, TileManaFabricator.class, "ManaFabricator");
 		registerTileEntity(TMBlocks.processorBO, TileBOProcessor.class, "TileProcessorBO");
 		registerTileEntity(TMBlocks.manaExchanger, TileManaExchanger.class, "TileManaExchanger");
-		
-		registerBucket(TMBlocks.manaFluid, TMBlocks.manaFluidBlock, TMItems.manaBucket);
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/lib/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/lib/compat/Thaumcraft.java
@@ -21,6 +21,7 @@ import thaumcraft.api.aspects.IEssentiaTransport;
 import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.items.wands.ItemWandCasting;
+import theflogat.technomancy.Technomancy;
 import theflogat.technomancy.common.blocks.air.BlockFakeAirNG;
 import theflogat.technomancy.common.blocks.base.BlockCosmeticOpaque;
 import theflogat.technomancy.common.blocks.base.TMBlocks;
@@ -166,6 +167,17 @@ public class Thaumcraft extends ModuleBase {
 		itemWandCap =  GameRegistry.findItem("Thaumcraft", "WandCap");
 		itemWandCasting =  GameRegistry.findItem("Thaumcraft", "WandCasting");
 		itemPickThaumium = GameRegistry.findItem("Thaumcraft", "ItemPickThaumium");
+		
+		if(FLUXGOO != null && blockCosmeticSolid != null && blockMetalDevice != null && blockStoneDevice != null &&
+				blockJar != null && blockTube != null && blockCustomPlant != null && blockWoodenDevice != null &&
+				blockTable != null && itemResource != null && itemEssence != null && itemNugget != null &&
+				itemShard != null && itemWandRod != null && itemWandCap != null && itemWandCasting != null &&
+				itemPickThaumium != null) {
+			Technomancy.logger.info("Thaumcraft compatibility module loaded.");
+		} else {
+			Technomancy.logger.warn("Thaumcraft compatibility module failed to load.");
+			CompatibilityHandler.th = false;
+		}
 	}
 
 	@Override

--- a/src/main/java/theflogat/technomancy/lib/compat/waila/WailaProvider.java
+++ b/src/main/java/theflogat/technomancy/lib/compat/waila/WailaProvider.java
@@ -12,6 +12,7 @@ import theflogat.technomancy.common.tiles.thaumcraft.machine.TileEldritchConsume
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileEssentiaFusor;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileFluxLamp;
 import theflogat.technomancy.common.tiles.thaumcraft.machine.TileNodeGenerator;
+import theflogat.technomancy.lib.handlers.CompatibilityHandler;
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
 
@@ -19,35 +20,41 @@ public class WailaProvider {
 	public static void callbackRegister(IWailaRegistrar registrar) {
 		registrar.registerBodyProvider(new DynamoHUDHandler(), TileDynamoBase.class);
 		
-		IWailaDataProvider biomeMorpher = new BiomeMorpherHUDHandler();
-		registrar.registerBodyProvider(biomeMorpher, TileBiomeMorpher.class);
-		registrar.registerNBTProvider(biomeMorpher, TileBiomeMorpher.class);
-	
-		IWailaDataProvider nodeGenerator = new NodeGeneratorHUDHandler();
-		registrar.registerBodyProvider(nodeGenerator, TileNodeGenerator.class);
-		registrar.registerNBTProvider(nodeGenerator, TileNodeGenerator.class);
-		
-		IWailaDataProvider nodeGeneratorAir = new FakeAirNGHUDHandler();
-		registrar.registerBodyProvider(nodeGeneratorAir, TileFakeAirNG.class);
-		registrar.registerNBTProvider(nodeGeneratorAir, TileFakeAirNG.class);
-		registrar.registerStackProvider(nodeGeneratorAir, TileFakeAirNG.class);
-		
-		registrar.registerBodyProvider(new EldritchConsumerHUDHandler(), TileEldritchConsumer.class);
-		
-		registrar.registerBodyProvider(new BloodFabricatorHUDHandler(), TileBloodFabricator.class);
-		
-		registrar.registerBodyProvider(new FluxLampHUDHandler(), TileFluxLamp.class);
-		
 		registrar.registerBodyProvider(new CatalystHUDHandler(), TileCatalyst.class);
 		
 		registrar.registerBodyProvider(new ProcessorHUDHandler(), TileProcessorBase.class);
 		
-		IWailaDataProvider manaExchanger = new ManaExchangerHUDHandler();
-		registrar.registerBodyProvider(manaExchanger, TileManaExchanger.class);
-		registrar.registerNBTProvider(manaExchanger, TileManaExchanger.class);
-		
 		registrar.registerBodyProvider(new CoilTransmitterHUDHandler(), TileCoilTransmitter.class);
 		
-		registrar.registerBodyProvider(new EssentiaFusorHUDHandler(), TileEssentiaFusor.class);
+		if(CompatibilityHandler.th) {
+			IWailaDataProvider biomeMorpher = new BiomeMorpherHUDHandler();
+			registrar.registerBodyProvider(biomeMorpher, TileBiomeMorpher.class);
+			registrar.registerNBTProvider(biomeMorpher, TileBiomeMorpher.class);
+		
+			IWailaDataProvider nodeGenerator = new NodeGeneratorHUDHandler();
+			registrar.registerBodyProvider(nodeGenerator, TileNodeGenerator.class);
+			registrar.registerNBTProvider(nodeGenerator, TileNodeGenerator.class);
+			
+			IWailaDataProvider nodeGeneratorAir = new FakeAirNGHUDHandler();
+			registrar.registerBodyProvider(nodeGeneratorAir, TileFakeAirNG.class);
+			registrar.registerNBTProvider(nodeGeneratorAir, TileFakeAirNG.class);
+			registrar.registerStackProvider(nodeGeneratorAir, TileFakeAirNG.class);
+			
+			registrar.registerBodyProvider(new EldritchConsumerHUDHandler(), TileEldritchConsumer.class);
+			
+			registrar.registerBodyProvider(new FluxLampHUDHandler(), TileFluxLamp.class);
+			
+			registrar.registerBodyProvider(new EssentiaFusorHUDHandler(), TileEssentiaFusor.class);
+		}
+		
+		if(CompatibilityHandler.bo) {
+			IWailaDataProvider manaExchanger = new ManaExchangerHUDHandler();
+			registrar.registerBodyProvider(manaExchanger, TileManaExchanger.class);
+			registrar.registerNBTProvider(manaExchanger, TileManaExchanger.class);
+		}
+		
+		if(CompatibilityHandler.bm) {
+			registrar.registerBodyProvider(new BloodFabricatorHUDHandler(), TileBloodFabricator.class);
+		}
     }
 }


### PR DESCRIPTION
Fixes:
- Boosted coils no longer deactivate themselves due to redstone output. When the Potency Gem is used on a coil, the coil is switched to ignore redstone, and if modified with an item, the item is dropped. Further attempts to modify the redstone behavior are ignored. When Potency Gem is removed, coil is returned to requiring a "Low" redstone signal to function, and redstone modifying items can be used again.
- Descriptions on Light and Dark crystals were reversed.
- Waila tooltips did not function if some mods were not loaded. Waila should now show tooltips for blocks for blocks even if all mods are not active.
- Clearing the filter on the Item Coil did not properly propagate from server to client.
- Fixed exception when reading item info for blocks that have a tank with no fluid/fluid type in it.
- Fixed syncing of blood tank content from server -> client for Blood Dynamo
- Fixed flickering block on rotation of Dynamos
- Fixed bucket picking up water instead of Mana Condensate when used on a Mana Condensate block

Changes:
- Changed IRedstoneSensitive and blocks that handle changing redstone settings to allow tile entities to disallow changing redstone state. This was needed to prevent changing redstone state on coils that were "boosted".
- Rendering of "rings" on coils changed. Top ring will be red if coil is "boosted". Bottom ring is used to indicate if the coil is filtered.
- Info for items cleaned up a little
- Added logging of Thaumcraft module loading success/failure
- Added Logging for Botaina module init
- Changed facing on placement of the mana fabricator to use block metadata instead of a block variable
- Added ability to rotate Mana Fabricator with a wrench
- Added both charged and uncharged wand and scepter to creative menu
- Electric Bellows now cause Essentia to funnel into Alembics faster as if Alumentum had been used as fuel