### PR TITLE
Added support for Thaumic Pipes.

### DIFF
--- a/src/api/java/me/jezza/thaumicpipes/api/TileType.java
+++ b/src/api/java/me/jezza/thaumicpipes/api/TileType.java
@@ -1,0 +1,16 @@
+package me.jezza.thaumicpipes.api;
+
+/**
+ * Used to flag what type of tile it is. Either given a direction or not.
+ */
+public enum TileType {
+    INPUT,
+    STORAGE,
+    OUTPUT;
+
+    public static final int[] OPPOSITES = {2, 1, 0};
+
+    public TileType getOpposite() {
+        return values()[OPPOSITES[ordinal()]];
+    }
+}

--- a/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicInput.java
+++ b/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicInput.java
@@ -1,0 +1,10 @@
+package me.jezza.thaumicpipes.api.interfaces;
+
+/**
+ * This interface solely requires input from the network.
+ * For example:
+ * The Alchemical Construct is a sole input.
+ * It just takes from the network.
+ */
+public interface IThaumicInput {
+}

--- a/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicOutput.java
+++ b/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicOutput.java
@@ -1,0 +1,10 @@
+package me.jezza.thaumicpipes.api.interfaces;
+
+/**
+ * This interface solely outputs into the network.
+ * For example:
+ * The Alembic is a sole input.
+ * It just puts it into the network.
+ */
+public interface IThaumicOutput {
+}

--- a/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicStorage.java
+++ b/src/api/java/me/jezza/thaumicpipes/api/interfaces/IThaumicStorage.java
@@ -1,0 +1,25 @@
+package me.jezza.thaumicpipes.api.interfaces;
+
+/**
+ * This interface is both an input and an output.
+ * If you have a directional block, you can probably just extend the TileProperties objects.
+ *
+ * Two examples:
+ * Firstly, an actual storage device.
+ * The jar. It's a storage device. It holds it for the network. Nothing more.
+ *
+ * Second example, in which case, you need to use the directional functions of TileProperties:
+ * The centrifuge is both an input and an output.
+ * It inputs into the bottom, and pushes it out the top.
+ *
+ * So, in my code, I register it as such:
+ * ThaumicRegistry.registerTile(TileCentrifuge.class, TileProperties.OUTPUT.addDirectionalFlag(ForgeDirection.DOWN, TileType.INPUT));
+ *
+ * Simple as that.
+ * This tells the network that it's going to be putting into the top of the network, and pulling out from the top.
+ *
+ * Makes the whole process faster.
+ * If I just registered the centrifuge as a storage device, the network treats it as a device that SOLELY HOLDS the essentia.
+ */
+public interface IThaumicStorage {
+}

--- a/src/api/java/me/jezza/thaumicpipes/api/package-info.java
+++ b/src/api/java/me/jezza/thaumicpipes/api/package-info.java
@@ -1,0 +1,5 @@
+@API(owner = "ThaumicPipes", apiVersion = "1.2.00", provides = "ThaumicPipes|API")
+package me.jezza.thaumicpipes.api;
+
+import cpw.mods.fml.common.API;
+

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/dynamos/TileEssentiaDynamo.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/dynamos/TileEssentiaDynamo.java
@@ -2,6 +2,8 @@ package theflogat.technomancy.common.tiles.thaumcraft.dynamos;
 
 import java.util.Random;
 
+import cpw.mods.fml.common.Optional;
+import me.jezza.thaumicpipes.api.interfaces.IThaumicInput;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -14,7 +16,8 @@ import theflogat.technomancy.common.tiles.base.TileDynamoBase;
 import theflogat.technomancy.lib.compat.Thaumcraft;
 import thaumcraft.common.lib.world.ThaumcraftWorldGenerator;
 
-public class TileEssentiaDynamo extends TileDynamoBase implements IAspectContainer, IEssentiaTransport{
+@Optional.Interface(iface = "me.jezza.thaumicpipes.api.interfaces.IThaumicInput", modid = "ThaumicPipes")
+public class TileEssentiaDynamo extends TileDynamoBase implements IAspectContainer, IEssentiaTransport, IThaumicInput {
 
 	private int amount;
 	private int maxAmount = 64;

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileCondenser.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileCondenser.java
@@ -2,6 +2,8 @@ package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
 import java.util.HashMap;
 
+import cpw.mods.fml.common.Optional;
+import me.jezza.thaumicpipes.api.interfaces.IThaumicOutput;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import thaumcraft.api.aspects.Aspect;
@@ -14,7 +16,8 @@ import theflogat.technomancy.common.tiles.base.TileMachineRedstone;
 import theflogat.technomancy.lib.compat.Thaumcraft;
 import theflogat.technomancy.lib.handlers.Rate;
 
-public class TileCondenser extends TileMachineRedstone implements IEssentiaTransport, IAspectSource, IWrenchable {
+@Optional.Interface(iface = "me.jezza.thaumicpipes.api.interfaces.IThaumicOutput", modid = "ThaumicPipes")
+public class TileCondenser extends TileMachineRedstone implements IEssentiaTransport, IAspectSource, IWrenchable, IThaumicOutput {
 
 	public static final Aspect aspect = Aspect.ENERGY;
 

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileEldritchConsumer.java
@@ -2,6 +2,8 @@ package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
 import java.util.ArrayList;
 
+import cpw.mods.fml.common.Optional;
+import me.jezza.thaumicpipes.api.interfaces.IThaumicOutput;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -18,7 +20,8 @@ import theflogat.technomancy.common.tiles.base.TileMachineRedstone;
 import theflogat.technomancy.lib.handlers.Rate;
 import theflogat.technomancy.util.Coords;
 
-public class TileEldritchConsumer extends TileMachineRedstone implements IAspectContainer, IEssentiaTransport {
+@Optional.Interface(iface = "me.jezza.thaumicpipes.api.interfaces.IThaumicOutput", modid = "ThaumicPipes")
+public class TileEldritchConsumer extends TileMachineRedstone implements IAspectContainer, IEssentiaTransport, IThaumicOutput {
 
 	public enum Range {
 		LARGE(9, -1, 0, "Large"),

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileFluxLamp.java
@@ -1,5 +1,7 @@
 package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
+import cpw.mods.fml.common.Optional;
+import me.jezza.thaumicpipes.api.interfaces.IThaumicInput;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -18,7 +20,8 @@ import theflogat.technomancy.common.tiles.base.TileTechnomancy;
 import theflogat.technomancy.lib.compat.Thaumcraft;
 import theflogat.technomancy.util.helpers.WorldHelper;
 
-public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, IEssentiaTransport, IFluidHandler{
+@Optional.Interface(iface = "me.jezza.thaumicpipes.api.interfaces.IThaumicInput", modid = "ThaumicPipes")
+public class TileFluxLamp extends TileTechnomancy implements IAspectContainer, IEssentiaTransport, IFluidHandler, IThaumicInput {
 
 	int amount = 0;
 	int maxAmount = 32;

--- a/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTCProcessor.java
+++ b/src/main/java/theflogat/technomancy/common/tiles/thaumcraft/machine/TileTCProcessor.java
@@ -1,5 +1,7 @@
 package theflogat.technomancy.common.tiles.thaumcraft.machine;
 
+import cpw.mods.fml.common.Optional;
+import me.jezza.thaumicpipes.api.interfaces.IThaumicInput;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -11,7 +13,8 @@ import thaumcraft.api.aspects.IEssentiaTransport;
 import theflogat.technomancy.common.tiles.base.TileProcessorBase;
 import theflogat.technomancy.lib.compat.Thaumcraft;
 
-public class TileTCProcessor extends TileProcessorBase implements IAspectContainer, IEssentiaTransport {
+@Optional.Interface(iface = "me.jezza.thaumicpipes.api.interfaces.IThaumicInput", modid = "ThaumicPipes")
+public class TileTCProcessor extends TileProcessorBase implements IAspectContainer, IEssentiaTransport, IThaumicInput {
 	
 	public int amount = 0;
 	public int maxAmount = 64;


### PR DESCRIPTION
The Node Fabricator and Essentia Fusor are not supported as Thaumic Pipes does not seem to understand a block that both inputs and outputs Essentia, but doesn't have predefined sides for this.

Mostly Fixes #119