### PR TITLE
Adds a Coremod component to Technomancy.

### DIFF
--- a/src/main/java/theflogat/technomancy/asm/TechnomancyCore.java
+++ b/src/main/java/theflogat/technomancy/asm/TechnomancyCore.java
@@ -1,0 +1,43 @@
+package theflogat.technomancy.asm;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+import theflogat.technomancy.lib.Ref;
+import cpw.mods.fml.common.DummyModContainer;
+import cpw.mods.fml.common.LoadController;
+import cpw.mods.fml.common.ModMetadata;
+import cpw.mods.fml.common.event.FMLConstructionEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.Mod.EventHandler;
+
+public class TechnomancyCore extends DummyModContainer {
+	public TechnomancyCore() {
+		super(new ModMetadata());
+		ModMetadata metadata = getMetadata();
+		metadata.modId = Ref.MOD_ID + "Core";
+		metadata.name = Ref.MOD_NAME + " Core";
+		metadata.version = Ref.MOD_VERSION;
+		metadata.authorList.add("Mordenkainen");
+	}
+	
+	@Override
+	public boolean registerBus(EventBus bus, LoadController controller)
+	{
+		bus.register(this);
+		return true;
+	}
+	
+	@Subscribe
+	public void modConstruction(FMLConstructionEvent event) {
+	}
+	
+	@EventHandler
+	public void preinit(FMLPreInitializationEvent event) {
+	}
+	
+	@EventHandler
+	public void postInit(FMLPostInitializationEvent event) {
+	}
+}

--- a/src/main/java/theflogat/technomancy/asm/TechnomancyCoreLoader.java
+++ b/src/main/java/theflogat/technomancy/asm/TechnomancyCoreLoader.java
@@ -1,0 +1,36 @@
+package theflogat.technomancy.asm;
+
+import java.util.Map;
+
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+import theflogat.technomancy.lib.Ref;
+
+@IFMLLoadingPlugin.MCVersion("1.7.10")
+@IFMLLoadingPlugin.Name(Ref.MOD_NAME + " Core")
+public class TechnomancyCoreLoader implements IFMLLoadingPlugin {
+
+	@Override
+	public String[] getASMTransformerClass() {
+		return new String[] {TechnomancyCoreTransformer.class.getName()};
+	}
+
+	@Override
+	public String getModContainerClass() {
+		return TechnomancyCore.class.getName();
+	}
+
+	@Override
+	public String getSetupClass() {
+		return null;
+	}
+
+	@Override
+	public void injectData(Map<String, Object> data) {}
+
+	@Override
+	public String getAccessTransformerClass() {
+		return null;
+	}
+
+}

--- a/src/main/java/theflogat/technomancy/asm/TechnomancyCoreTransformer.java
+++ b/src/main/java/theflogat/technomancy/asm/TechnomancyCoreTransformer.java
@@ -1,0 +1,86 @@
+package theflogat.technomancy.asm;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import net.minecraft.launchwrapper.Launch;
+
+public class TechnomancyCoreTransformer implements IClassTransformer {
+
+	static boolean isDeobfEnvironment;
+	
+	@Override
+	public byte[] transform(String name, String transformedName, byte[] basicClass) {
+		isDeobfEnvironment = (Boolean)Launch.blackboard.get("fml.deobfuscatedEnvironment");
+				
+		if(name.equals("powercrystals.minefactoryreloaded.MineFactoryReloadedClient")) {
+			byte[] newCode = patchRenderWorldLast(basicClass, isDeobfEnvironment);
+			return newCode;
+		}
+		
+		return basicClass;
+	}
+
+	private byte[] patchRenderWorldLast(byte[] origCode, boolean isDeobfEnvironment) {
+		ClassReader cr = new ClassReader(origCode);
+
+		ClassNode classNode=new ClassNode();
+		cr.accept(classNode, 0);
+
+		for(MethodNode methodNode : classNode.methods) {
+			if(methodNode.name.equals("renderWorldLast") && methodNode.desc.equals("(Lnet/minecraftforge/client/event/RenderWorldLastEvent;)V"))	{
+				Iterator<AbstractInsnNode> insnNodes=methodNode.instructions.iterator();
+				boolean foundIf = false;
+				boolean foundJump = false;
+				LabelNode label = new LabelNode();
+				LabelNode retNode = new LabelNode();
+				while(insnNodes.hasNext() && !foundIf) {
+					AbstractInsnNode insn=insnNodes.next();
+					
+					if(insn.getOpcode()==Opcodes.IFNULL && !foundJump) {
+						foundJump = true;
+						((JumpInsnNode)insn).label = retNode;
+					}
+					if(insn.getOpcode()==Opcodes.RETURN) {
+						foundIf = true;
+						InsnList endList=new InsnList();
+						endList.add(new VarInsnNode(Opcodes.ALOAD, 2));
+						endList.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/entity/player/EntityPlayer", "field_71071_by", "Lnet/minecraft/entity/player/InventoryPlayer;"));
+						endList.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/entity/player/InventoryPlayer", "func_70448_g", "()Lnet/minecraft/item/ItemStack;", false));
+						endList.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/item/ItemStack", "func_77973_b", "()Lnet/minecraft/item/Item;", false));
+						endList.add(new TypeInsnNode(Opcodes.INSTANCEOF, "theflogat/technomancy/common/items/thaumcraft/ItemTechnoturgeScepter"));
+						endList.add(new JumpInsnNode(Opcodes.IFNE, label));
+						endList.add(retNode);
+						methodNode.instructions.insertBefore(insn, endList);
+						methodNode.instructions.insert(insn, label);
+					}
+				}
+			}
+		}
+		
+		ClassWriter cw=new ClassWriter(ClassWriter.COMPUTE_MAXS);
+		classNode.accept(cw);
+		
+		return cw.toByteArray();
+	}
+
+}


### PR DESCRIPTION
Currently it only modifies MFR to allow the Technoturges Scepter to display the MFR machine radius like the Sledgehammer/FactoryHammer.

Fixes #121

Note that this requires some changes to the dev environment and build script to function properly.

Eclipse:
Add the following to the VM Arguments section of your Run Configurations 
```
-Dfml.coreMods.load=theflogat.technomancy.asm.TechnomancyCoreLoader"
```

build.gradle:
Add the follow section to build.gradle, right after the "minecraft" section.
```
jar {
    manifest {
        attributes 'FMLCorePlugin': 'theflogat.technomancy.asm.TechnomancyCoreLoader',
                   'FMLCorePluginContainsFMLMod': 'true'
    }
}
```