### PR TITLE
Added ability to use standard Warded Jars like a Phial with the Quant…

### DIFF
--- a/src/main/java/theflogat/technomancy/lib/compat/Thaumcraft.java
+++ b/src/main/java/theflogat/technomancy/lib/compat/Thaumcraft.java
@@ -82,6 +82,7 @@ public class Thaumcraft extends ModuleBase {
 	public static Item itemWandCap;
 	public static Item itemWandCasting;
 	public static Item itemPickThaumium;
+	public static Item itemJarFilled;
 
 	public static Block blockCosmeticSolid;
 	public static Block blockMetalDevice;
@@ -165,12 +166,13 @@ public class Thaumcraft extends ModuleBase {
 		itemWandCap =  GameRegistry.findItem("Thaumcraft", "WandCap");
 		itemWandCasting =  GameRegistry.findItem("Thaumcraft", "WandCasting");
 		itemPickThaumium = GameRegistry.findItem("Thaumcraft", "ItemPickThaumium");
+		itemJarFilled = GameRegistry.findItem("Thaumcraft", "BlockJarFilledItem");
 		
 		if(FLUXGOO != null && blockCosmeticSolid != null && blockMetalDevice != null && blockStoneDevice != null &&
 				blockJar != null && blockTube != null && blockCustomPlant != null && blockWoodenDevice != null &&
 				blockTable != null && itemResource != null && itemEssence != null && itemNugget != null &&
 				itemShard != null && itemWandRod != null && itemWandCap != null && itemWandCasting != null &&
-				itemPickThaumium != null) {
+				itemPickThaumium != null && itemJarFilled!= null) {
 			Technomancy.logger.info("Thaumcraft compatibility module loaded.");
 		} else {
 			Technomancy.logger.warn("Thaumcraft compatibility module failed to load.");


### PR DESCRIPTION
…um Jar.

Empty, unlabeled Warded Jars can be filled from a Quantum Jar by right-clicking.

Filled Warded Jars (labeled or unlabeled) can be emptied into the Quantum Jar by right-clicking as long as the Aspect/filter matches, or if the Quantum jar is empty and unlabeled.

Fixes #113